### PR TITLE
HAPI Reader

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,7 @@ lazy val hapi = (project in file("."))
     libraryDependencies ++= Seq(
       // "io.latis-data"           %% "latis-core"      % latisVersion,
       "org.http4s"             %% "http4s-blaze-client" % http4sVersion,
+      "org.http4s" %% "http4s-circe"        % http4sVersion,
       "io.circe" %% "circe-core"   % circeVersion,
       "io.circe" %% "circe-parser" % circeVersion
     )

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,7 @@ ThisBuild / organization := "io.latis-data"
 ThisBuild / scalaVersion := "2.12.8"
 
 //val latisVersion    = "3.0.0-SNAPSHOT"
+val circeVersion      = "0.12.3"
 val http4sVersion     = "0.20.13"
 
 lazy val `latis3-core` = ProjectRef(file("../latis3"), "core")
@@ -14,6 +15,8 @@ lazy val hapi = (project in file("."))
     libraryDependencies ++= Seq(
       // "io.latis-data"           %% "latis-core"      % latisVersion,
       "org.http4s"             %% "http4s-blaze-client" % http4sVersion,
+      "io.circe" %% "circe-core"   % circeVersion,
+      "io.circe" %% "circe-parser" % circeVersion
     )
   )
   

--- a/src/main/scala/latis/input/HapiReader.scala
+++ b/src/main/scala/latis/input/HapiReader.scala
@@ -1,0 +1,235 @@
+package latis.input
+
+import java.net.URI
+
+import scala.concurrent.ExecutionContext
+
+import cats.effect.IO
+import cats.effect.Resource
+import cats.implicits._
+import io.circe.Decoder
+import io.circe.Json
+import org.http4s.Uri
+import org.http4s.client.Client
+import org.http4s.client.blaze.BlazeClientBuilder
+import org.http4s.circe._
+
+import latis.dataset.AdaptedDataset
+import latis.dataset.Dataset
+import latis.metadata.Metadata
+import latis.model._
+import latis.time.Time
+import latis.util.hapi._
+import latis.util.StreamUtils.contextShift
+
+/**
+ * A reader for datasets accessible though a HAPI service.
+ *
+ * This reader makes some assumptions about the dataset being read:
+ *
+ * - At least one range variable has been projected.
+ * - Every range variable is a function of every domain variable.
+ * - The dataset is a timeseries or has a single nested function.
+ *
+ * These assumptions translate to the following requirements on the
+ * HAPI parameters:
+ *
+ * - If any parameter has bins, all parameters are assumed to have the
+ *   same set of bins.
+ * - Every parameter has zero bins, or every parameter has the same
+ *   bin.
+ * - The size of every parameter is undefined (a scalar) or is one
+ *   dimensional (a tuple or array).
+ */
+class HapiReader extends DatasetReader {
+
+  /**
+   * Makes a LaTiS Dataset from a HAPI info request.
+   *
+   * @param uri URI for HAPI info request for a dataset
+   */
+  override def read(uri: URI): Option[Dataset] = for {
+    id      <- getId(uri)
+    json    <- makeInfoRequest(uri) match {
+      case Right(json) => Option(json)
+      case Left(err)   => throw err
+    }
+    _       <- isHapiResponse(json).guard[Option]
+    baseUri <- getBaseUri(uri)
+    info    <- parseInfo(json) match {
+      case Right(info) => Option(info)
+      case Left(err)   => throw err
+    }
+    metadata = Metadata(id)
+    model   <- toModel(info.parameters)
+    adapter  = new HapiCsvAdapter(
+      model,
+      new HapiAdapter.Config(
+        "class" -> "latis.input.HapiCsvAdapter",
+        "id"    -> id
+      )
+    )
+    dataset  = new AdaptedDataset(metadata, model, adapter, baseUri)
+  } yield dataset
+
+  private def httpClient: Resource[IO, Client[IO]] =
+    BlazeClientBuilder[IO](ExecutionContext.global).resource
+
+  private def makeInfoRequest(uri: URI): Either[Throwable, Json] = for {
+    infoUri <- Uri.fromString(uri.toString())
+    json    <- httpClient.use(_.expect[Json](infoUri)).attempt.unsafeRunSync()
+  } yield json
+
+  private def parseInfo(json: Json): Either[Throwable, Info] =
+    Decoder[Info].decodeJson(json)
+
+  private def isHapiResponse(json: Json): Boolean =
+    json.hcursor.get[String]("HAPI").isRight
+
+  /** Parses dataset ID from a HAPI request. */
+  private def getId(infoUri: URI): Option[String] = for {
+    query <- Option(infoUri.getQuery())
+    regex  = """id=([^&]+)""".r
+    mtch  <- regex.findFirstMatchIn(query)
+    id    <- if (mtch.groupCount > 0) Option(mtch.group(1)) else None
+  } yield id
+
+  /** Gets the base URI of a HAPI service from the info URI. */
+  private def getBaseUri(infoUri: URI): Option[URI] = for {
+    scheme <- Option(infoUri.getScheme())
+    host   <- Option(infoUri.getHost())
+    path   <- Option(infoUri.getPath())
+    newPath = path.stripSuffix("info")
+    uri     = new URI(scheme, host, newPath, null)
+  } yield uri
+
+  /** Constructs the model from a list of HAPI parameters. */
+  private[input] def toModel(ps: List[Parameter]): Option[DataType] = ps match {
+    // Time will always be first, and we require that it be followed
+    // by at least one other parameter.
+    case (time: ScalarParameter) :: first :: rest =>
+      // This fold builds the range of the dataset by turning each
+      // HAPI parameter into a DataType and adding it to the model if
+      // it doesn't violate our stated assumptions.
+      val range: Option[DataType] = {
+        val dt = toDataType(first)
+        rest.foldM(dt)(addParameterToModel)
+      }
+
+      range.map(Function(toTime(time), _))
+    case _ => None
+  }
+
+  /** Adds a HAPI parameter to the LaTiS model. */
+  private val addParameterToModel: (DataType, Parameter) => Option[DataType] = {
+    // If there is a function in the range, the next parameter
+    // must share the same domain. (We check this by comparing the
+    // name of the next parameter's bin to the name of the domain
+    // of the function.)
+    case (Function(d: Scalar, r), p: ArrayParameter) if p.bin.name == d.id =>
+      val np = ScalarParameter(p.name, p.typeName, p.units, p.length, p.fill)
+      val newRange = addParameterToModel(r, np)
+      newRange.map(Function(d, _))
+    // Array parameters can only be placed in functions.
+    case (_, _: ArrayParameter) => None
+    // The next parameter for these cases will either be a scalar
+    // or a vector, and both are ok to add if we don't already
+    // have a function in the range.
+    case (s: Scalar, p)          => Option(Tuple(s, toDataType(p)))
+    case (t @ Tuple(xs @ _*), p) => if (t.id.isEmpty) {
+      // If the tuple's ID is an empty string, it is the anonymous
+      // tuple grouping the range variables.
+      Option(Tuple((xs :+ toDataType(p)): _*))
+    } else {
+      // If the existing tuple has an ID, it came from a vector.
+      Option(Tuple(t, toDataType(p)))
+    }
+    case _ => None
+  }
+
+  /** Constructs a LaTiS DataType from a HAPI parameter. */
+  private def toDataType(p: Parameter): DataType = p match {
+    case p: ScalarParameter => toScalar(p)
+    case p: VectorParameter => toTuple(p)
+    case p: ArrayParameter  => toFunction(p)
+  }
+
+  /** Constructs a LaTiS Function from a HAPI parameter. */
+  private def toFunction(p: ArrayParameter): Function = p match {
+    case ArrayParameter(name, tyName, units, length, fill, _, Bin(bName, bUnits)) =>
+      // The domain of the function is the bin as a Scalar.
+      val d: DataType = toScalar(
+        ScalarParameter(bName, "double", bUnits, None, None)
+      )
+
+      // The range of the function is the array parameter as a Scalar.
+      val r: DataType = toScalar(
+        ScalarParameter(name, tyName, units, length, fill)
+      )
+
+      Function(d, r)
+  }
+
+  /** Constructs a LaTiS Scalar from a HAPI parameter. */
+  private def toScalar(p: ScalarParameter): Scalar = p match {
+    case ScalarParameter(name, tyName, units, length, fill) =>
+      val md = makeMetadata(name, tyName, units, length, fill)
+      Scalar(md)
+  }
+
+  /** Constructs a LaTiS Tuple from a HAPI parameter. */
+  private def toTuple(p: VectorParameter): Tuple = p match {
+    case VectorParameter(name, tyName, units, length, fill, size) =>
+      val ds: List[DataType] = List.tabulate(size) { n =>
+        val md = makeMetadata(s"${name}._$n", tyName, units, length, fill)
+        Scalar(md)
+      }
+      Tuple(Metadata("id" -> name), ds:_*)
+  }
+
+  /** Constructs a LaTiS Time value from a HAPI parameter. */
+  private def toTime(p: ScalarParameter): Time = p match {
+    case ScalarParameter(_, _, _, l @ Some(length), _) =>
+      val md = makeMetadata("time", "string", getTimeFormat(length), l, None)
+      Time(md)
+    case _ => throw new RuntimeException("Time parameter requires length.")
+  }
+
+  /** Determines time format from reported time string length. */
+  private def getTimeFormat(length: Int): String = length match {
+    case 24 => "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+    case 22 => "yyyy-ddd'T'HH:mm:ss.SSS'Z'"
+    case 20 => "yyyy-MM-dd'T'HH:mm:ss'Z'"
+    case 18 => "yyyy-ddd'T'HH:mm:ss'Z'"
+    case 17 => "yyyy-MM-dd'T'HH:mm'Z'"
+    case 15 => "yyyy-ddd'T'HH:mm'Z'"
+    case 14 => "yyyy-MM-dd'T'HH'Z'"
+    case 12 => "yyyy-ddd'T'HH'Z'"
+    case 11 => "yyyy-MM-dd'Z'"
+    case 9  => "yyyy-ddd'Z'"
+    case 8  => "yyyy-MM'Z'"
+    case 5  => "yyyy'Z'"
+    case _ => throw new RuntimeException("Could not determine time format.")
+  }
+
+  /** Makes LaTiS Metadata from HAPI parameter metadata. */
+  private def makeMetadata(
+    id: String,
+    tyName: String,
+    units: String,
+    length: Option[Int],
+    fill: Option[String]
+  ): Metadata = {
+    val tn = tyName match {
+      case "isotime" => "string"
+      case "integer" => "int"
+      case t         => t
+    }
+
+    val b = Metadata("id" -> id, "type" -> tn, "units" -> units)
+    val l = length.fold(Metadata())(l => Metadata("length" -> l.toString()))
+    val f = fill.fold(Metadata())(f => Metadata("fill" -> f))
+
+    b ++ l ++ f
+  }
+}

--- a/src/main/scala/latis/util/hapi/Bin.scala
+++ b/src/main/scala/latis/util/hapi/Bin.scala
@@ -1,0 +1,11 @@
+package latis.util.hapi
+
+import io.circe.Decoder
+
+/** A bin for a HAPI [[Parameter]]. */
+final case class Bin(name: String, units: String)
+
+object Bin {
+  implicit val decodeBin: Decoder[Bin] =
+    Decoder.forProduct2("name", "units")(Bin.apply)
+}

--- a/src/main/scala/latis/util/hapi/Info.scala
+++ b/src/main/scala/latis/util/hapi/Info.scala
@@ -1,0 +1,15 @@
+package latis.util.hapi
+
+import io.circe.Decoder
+
+/** Response from a HAPI `info` endpoint. */
+final case class Info(
+  startDate: String,
+  stopDate: String,
+  parameters: List[Parameter]
+)
+
+object Info {
+  implicit val infoDecoder: Decoder[Info] =
+    Decoder.forProduct3("startDate", "stopDate", "parameters")(Info.apply)
+}

--- a/src/main/scala/latis/util/hapi/parameter.scala
+++ b/src/main/scala/latis/util/hapi/parameter.scala
@@ -1,0 +1,85 @@
+package latis.util.hapi
+
+import io.circe.Decoder
+import io.circe.DecodingFailure
+import io.circe.HCursor
+
+/**
+ * Base type for HAPI parameter information.
+ *
+ * These types encode parameter information as LaTiS consumes it and
+ * are not meant to reflect the exact response from a HAPI service.
+ */
+sealed trait Parameter
+
+/** Represents a parameter without size or bins. */
+final case class ScalarParameter(
+  name: String,
+  typeName: String,
+  units: String,
+  length: Option[Int],
+  fill: Option[String]
+) extends Parameter
+
+/** Represents a parameter with size but without bins. */
+final case class VectorParameter(
+  name: String,
+  typeName: String,
+  units: String,
+  length: Option[Int],
+  fill: Option[String],
+  size: Int
+) extends Parameter
+
+/** Represents a parameter with size and bins. */
+final case class ArrayParameter(
+  name: String,
+  typeName: String,
+  units: String,
+  length: Option[Int],
+  fill: Option[String],
+  size: Int,
+  bin: Bin
+) extends Parameter
+
+object Parameter {
+
+  implicit val decodeParameter: Decoder[Parameter] = new Decoder[Parameter] {
+    final def apply(c: HCursor): Decoder.Result[Parameter] = for {
+      name   <- c.get[String]("name")
+      tyName <- c.get[String]("type")
+      units  <- c.get[String]("units")
+      // Only time and string parameters have length.
+      length <- if (tyName == "string" || tyName == "isotime") {
+        c.get[Int]("length").map(Option(_))
+      } else Right(None)
+      fill   <- c.get[Option[String]]("fill")
+      // We only support a single dimension if size is defined.
+      size   <- c.get[Option[List[Int]]]("size").flatMap {
+        case Some(s :: Nil) => Right(Option(s))
+        case None           => Right(None)
+        case _              => Left(DecodingFailure("Size", c.history))
+      }
+      // There will only be bins if size was defined. We only support
+      // a single bin if any are defined.
+      bin   <- size match {
+        case Some(_) => c.get[Option[List[Bin]]]("bins").flatMap {
+          case Some(b :: Nil) => Right(Option(b))
+          case None           => Right(None)
+          case _              => Left(DecodingFailure("Bins", c.history))
+        }
+        case None    => Right(None)
+      }
+      param <- bin match {
+        case Some(bin) => size match {
+          case Some(size) => Right(ArrayParameter(name, tyName, units, length, fill, size, bin))
+          case None       => Left(DecodingFailure("Parameter", c.history))
+        }
+        case None => size match {
+          case Some(size) => Right(VectorParameter(name, tyName, units, length, fill, size))
+          case None       => Right(ScalarParameter(name, tyName, units, length, fill))
+        }
+      }
+    } yield param
+  }
+}

--- a/src/test/resources/data/hapi-info.json
+++ b/src/test/resources/data/hapi-info.json
@@ -1,0 +1,24 @@
+{
+    "HAPI": "2.0",
+    "status": {"code": 1200, "message": "OK"},
+    "parameters": [
+        {
+            "name": "Time",
+            "type": "isotime",
+            "units": "UTC",
+            "length":24,
+            "fill": null
+        },
+        {
+            "name": "Np",
+            "type": "double",
+            "units": "#/cc",
+            "fill": "-1.0E31",
+            "description": "Solar Wind Proton Number Density, scalar"
+        }
+    ],
+    "startDate": "1998-02-04T00:00:31Z",
+    "stopDate": "2019-05-07T23:59:28Z",
+    "resourceURL": "https://cdaweb.sci.gsfc.nasa.gov/misc/Notes.html#AC_H0_SWE",
+    "contact": "voycrs@gmail.com"
+}

--- a/src/test/resources/data/hapi-parameter-array-multiple-bins.json
+++ b/src/test/resources/data/hapi-parameter-array-multiple-bins.json
@@ -1,0 +1,19 @@
+{
+    "name": "FPDU_plasmagram",
+    "type": "double",
+    "units": "cm!e-2!ns!e-1!nsr!e-1!nkeV!e-1!n",
+    "fill": "-1.0E31",
+    "size": [32,31],
+    "bins": [
+        {
+            "name": "FPDU_Alpha",
+            "units": "degrees",
+            "centers": []
+        },
+        {
+            "name": "FPDU_Energy",
+            "units": "keV",
+            "centers":[]
+        }
+    ]
+}

--- a/src/test/resources/data/hapi-parameter-array.json
+++ b/src/test/resources/data/hapi-parameter-array.json
@@ -1,0 +1,14 @@
+{
+    "name": "proton_spectrum_uncerts",
+    "type": "double",
+    "size": [3],
+    "units": "particles/(sec ster cm^2 keV)",
+    "fill": "-1e31",
+    "bins": [
+        {
+            "name": "energy",
+            "units": "keV",
+            "centers": [ 15, 25, 35 ]
+        }
+    ]
+}

--- a/src/test/resources/data/hapi-parameter-scalar.json
+++ b/src/test/resources/data/hapi-parameter-scalar.json
@@ -1,0 +1,7 @@
+{
+    "name": "Np",
+    "type": "double",
+    "units": "#/cc",
+    "fill": "-1.0E31",
+    "description": "Solar Wind Proton Number Density, scalar"
+}

--- a/src/test/resources/data/hapi-parameter-time.json
+++ b/src/test/resources/data/hapi-parameter-time.json
@@ -1,0 +1,7 @@
+{
+    "name": "Time",
+    "type": "isotime",
+    "units": "UTC",
+    "length":24,
+    "fill": null
+}

--- a/src/test/resources/data/hapi-parameter-vector.json
+++ b/src/test/resources/data/hapi-parameter-vector.json
@@ -1,0 +1,8 @@
+{
+    "name": "V_GSE",
+    "type": "double",
+    "units": "km/s",
+    "fill": "-1.0E31",
+    "description": "Solar Wind Velocity in GSE coord., 3 components",
+    "size": [3]
+}

--- a/src/test/scala/latis/input/HapiReaderSpec.scala
+++ b/src/test/scala/latis/input/HapiReaderSpec.scala
@@ -1,0 +1,213 @@
+package latis.input
+
+import java.net.URI
+
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+
+import latis.data._
+import latis.dataset.Dataset
+import latis.model._
+import latis.ops.Selection
+import latis.time.Time
+import latis.util.StreamUtils
+import latis.util.hapi._
+
+class HapiReaderSpec extends FlatSpec with Matchers {
+
+  val reader = new HapiReader()
+
+  "A HAPI reader" should "read a dataset from a HAPI service" in {
+    val uri = new URI("http://lasp.colorado.edu/lisird/hapi/info?id=nrl2_tsi_P1Y")
+
+    val ds = reader.read(uri)
+      .getOrElse(fail("Did not get dataset."))
+      .withOperation(Selection("time >= 2010"))
+      .withOperation(Selection("time <  2011"))
+
+    ds.id should be ("nrl2_tsi_P1Y")
+
+    ds.model match {
+      case Function(d: Scalar, Tuple(i: Scalar, u: Scalar)) =>
+        d.id should be ("time")
+        i.id should be ("irradiance")
+        u.id should be ("uncertainty")
+    }
+
+    StreamUtils.unsafeHead(ds.samples) match {
+      case Sample(DomainData(Text(time)), RangeData(Real(tsi), Real(unc))) =>
+        time should be ("2010-07-01T00:00:00.000Z")
+        tsi should be (1360.785400390625)
+        unc should be (0.10427488386631012)
+    }
+  }
+
+  it should "support scalar timeseries datasets" in {
+    val parameters: List[Parameter] = List(
+      ScalarParameter("time", "isotime", "UTC", Option(24), None),
+      ScalarParameter("x", "type", "units", None, None)
+    )
+
+    val model: DataType = reader.toModel(parameters).getOrElse(
+      fail("Failed to construct model.")
+    )
+
+    model match {
+      case Function(d: Time, r: Scalar) =>
+        d.id should be ("time")
+        r.id should be ("x")
+      case _ => fail(s"Unexpected model: $model")
+    }
+  }
+
+  it should "support vector timeseries datasets" in {
+    val parameters: List[Parameter] = List(
+      ScalarParameter("time", "isotime", "UTC", Option(24), None),
+      VectorParameter("x", "type", "units", None, None, 3)
+    )
+
+    val model: DataType = reader.toModel(parameters).getOrElse(
+      fail("Failed to construct model.")
+    )
+
+    model match {
+      case Function(d: Time, Tuple(x0, x1, x2)) =>
+        d.id should be ("time")
+        x0.id should be ("x._0")
+        x1.id should be ("x._1")
+        x2.id should be ("x._2")
+      case _ => fail(s"Unexpected model: $model")
+    }
+  }
+
+  it should "support scalars and vectors in datasets" in {
+    val parameters: List[Parameter] = List(
+      ScalarParameter("time", "isotime", "UTC", Option(24), None),
+      ScalarParameter("w", "type", "units", None, None),
+      VectorParameter("x", "type", "units", None, None, 2),
+      VectorParameter("y", "type", "units", None, None, 2),
+      ScalarParameter("z", "type", "units", None, None)
+    )
+
+    val model: DataType = reader.toModel(parameters).getOrElse(
+      fail("Failed to construct model.")
+    )
+
+    model match {
+      case Function(d: Time, Tuple(w, Tuple(x0, x1), Tuple(y0, y1), z)) =>
+        d.id should be ("time")
+        w.id should be ("w")
+        x0.id should be ("x._0")
+        x1.id should be ("x._1")
+        y0.id should be ("y._0")
+        y1.id should be ("y._1")
+        z.id should be ("z")
+      case _ => fail(s"Unexpected model: $model")
+    }
+  }
+
+  it should "support datasets with a vector as the first non-time parameter" in {
+    val parameters: List[Parameter] = List(
+      ScalarParameter("time", "isotime", "UTC", Option(24), None),
+      VectorParameter("x", "type", "units", None, None, 2),
+      ScalarParameter("y", "type", "units", None, None)
+    )
+
+    val model: DataType = reader.toModel(parameters).getOrElse(
+      fail("Failed to construct model.")
+    )
+
+    model match {
+      case Function(d: Time, Tuple(Tuple(x0, x1), y)) =>
+        d.id should be ("time")
+        x0.id should be ("x._0")
+        x1.id should be ("x._1")
+        y.id should be ("y")
+      case _ => fail(s"Unexpected model: $model")
+    }
+  }
+
+  it should "support array parameters in datasets" in {
+    val parameters: List[Parameter] = List(
+      ScalarParameter("time", "isotime", "UTC", Option(24), None),
+      ArrayParameter("x", "type", "units", None, None, 1,
+        Bin("w", "units")
+      )
+    )
+
+    val model: DataType = reader.toModel(parameters).getOrElse(
+      fail("Failed to construct model.")
+    )
+
+    model match {
+      case Function(d: Time, Function(w: Scalar, x: Scalar)) =>
+        d.id should be ("time")
+        w.id should be ("w")
+        x.id should be ("x")
+      case _ => fail(s"Unexpected model: $model")
+    }
+  }
+
+  it should "support multiple array parameters in datasets" in {
+    val parameters: List[Parameter] = List(
+      ScalarParameter("time", "isotime", "UTC", Option(24), None),
+      ArrayParameter("x", "type", "units", None, None, 1,
+        Bin("w", "units")
+      ),
+      ArrayParameter("y", "type", "units", None, None, 1,
+        Bin("w", "units")
+      ),
+      ArrayParameter("z", "type", "units", None, None, 1,
+        Bin("w", "units")
+      )
+    )
+
+    val model: DataType = reader.toModel(parameters).getOrElse(
+      fail("Failed to construct model.")
+    )
+
+    model match {
+      case Function(d: Time, Function(w: Scalar, Tuple(x: Scalar, y: Scalar, z: Scalar))) =>
+        d.id should be ("time")
+        w.id should be ("w")
+        x.id should be ("x")
+        y.id should be ("y")
+        z.id should be ("z")
+      case _ => fail(s"Unexpected model: $model")
+    }
+  }
+
+  it should "gracefully reject mixing array parameters with different bins" in {
+    val parameters: List[Parameter] = List(
+      ScalarParameter("time", "isotime", "UTC", Option(24), None),
+      ArrayParameter("x", "type", "units", None, None, 1,
+        Bin("w", "units")
+      ),
+      ArrayParameter("y", "type", "units", None, None, 1,
+        Bin("z", "units")
+      )
+    )
+
+    reader.toModel(parameters) should be (None)
+  }
+
+  it should "gracefully reject mixing array and other parameters" in {
+    val parameters: List[Parameter] = List(
+      ScalarParameter("time", "isotime", "UTC", Option(24), None),
+      ScalarParameter("x", "type", "units", None, None),
+      ArrayParameter("y", "type", "units", None, None, 1,
+        Bin("w", "units")
+      )
+    )
+
+    reader.toModel(parameters) should be (None)
+  }
+
+  it should "gracefully reject responses with only the time parameter" in {
+    val parameters: List[Parameter] = List(
+      ScalarParameter("time", "isotime", "UTC", Option(24), None)
+    )
+
+    reader.toModel(parameters) should be (None)
+  }
+}

--- a/src/test/scala/latis/util/JsonDecoderSpec.scala
+++ b/src/test/scala/latis/util/JsonDecoderSpec.scala
@@ -1,0 +1,62 @@
+package latis.util
+
+import scala.io.Source
+
+import io.circe.Decoder
+import io.circe.Json
+import io.circe.parser
+import org.scalatest.FlatSpec
+import org.scalatest.Inside
+import org.scalatest.Matchers
+
+/** A base class for testing JSON decoders. */
+abstract class JsonDecoderSpec extends FlatSpec with Inside with Matchers {
+
+  /**
+   * Parses JSON from a file on the classpath.
+   *
+   * Cancels the test if the required resource could not be read.
+   *
+   * @param resource path to resource
+   * @param f test to run with parsed JSON
+   */
+  def withJsonResource(resource: String)(f: Json => Any): Any =
+    try {
+      parser.parse(Source.fromResource(resource).mkString) match {
+        case Right(json) => f(json)
+        case Left(error) => cancel(error.getMessage)
+      }
+    } catch {
+      case _: NullPointerException =>
+        // Not finding a resource manifests as a null pointer.
+        cancel(s"Unable to find resource: $resource")
+    }
+
+  /**
+   * Decodes JSON to a given type.
+   *
+   * Fails the test if decoding fails.
+   *
+   * @param json JSON to decode
+   * @param f test to run with decoded value
+   */
+  def decodedAs[A: Decoder](json: Json)(f: A => Any): Any =
+    Decoder[A].decodeJson(json) match {
+      case Right(a) => f(a)
+      case Left(error) => fail(error.getMessage)
+    }
+
+  /**
+   * Checks that JSON does not decode to a given type.
+   *
+   * Fails the test if JSON successfully decodes.
+   *
+   * @param json JSON to decode
+   * @param msg message to print on failure
+   */
+  def doesNotDecodeAs[A: Decoder](json: Json)(msg: => String): Any =
+    Decoder[A].decodeJson(json) match {
+      case Left(_) => succeed
+      case _ => fail(msg)
+    }
+}

--- a/src/test/scala/latis/util/hapi/InfoDecoderSpec.scala
+++ b/src/test/scala/latis/util/hapi/InfoDecoderSpec.scala
@@ -1,0 +1,18 @@
+package latis.util
+package hapi
+
+/** Tests for decoding HAPI info responses. */
+class InfoDecoderSpec extends JsonDecoderSpec {
+
+  "The HAPI info response decoder" should "decode time coverage and parameters" in {
+    withJsonResource("data/hapi-info.json") {
+      decodedAs(_) { info: Info =>
+        inside(info) { case Info(startDate, stopDate, params) =>
+          startDate should be ("1998-02-04T00:00:31Z")
+          stopDate should be ("2019-05-07T23:59:28Z")
+          params should have size 2
+        }
+      }
+    }
+  }
+}

--- a/src/test/scala/latis/util/hapi/ParameterDecoderSpec.scala
+++ b/src/test/scala/latis/util/hapi/ParameterDecoderSpec.scala
@@ -1,0 +1,67 @@
+package latis.util
+package hapi
+
+/** Tests for decoding HAPI parameters. */
+class ParameterDecoderSpec extends JsonDecoderSpec {
+
+  "The HAPI parameter decoder" should "accept scalar parameters" in {
+    withJsonResource("data/hapi-parameter-scalar.json") {
+      decodedAs(_) { param: Parameter =>
+        inside(param) {
+          case ScalarParameter(name, tyName, units, length, fill) =>
+            name should be ("Np")
+            tyName should be ("double")
+            units should be ("#/cc")
+            length should be (None)
+            fill should be (Some("-1.0E31"))
+          case _ => fail("Decoded to wrong parameter type.")
+        }
+      }
+    }
+  }
+
+  it should "accept vector parameters" in {
+    withJsonResource("data/hapi-parameter-vector.json") {
+      decodedAs(_) { param: Parameter =>
+        inside(param) {
+          case VectorParameter(name, tyName, units, length, fill, size) =>
+            name should be ("V_GSE")
+            tyName should be ("double")
+            units should be ("km/s")
+            length should be (None)
+            fill should be (Some("-1.0E31"))
+            size should be (3)
+          case _ => fail("Decoded to wrong parameter type.")
+        }
+      }
+    }
+  }
+
+  it should "accept parameters with a single bin" in {
+    withJsonResource("data/hapi-parameter-array.json") {
+      decodedAs(_) { param: Parameter =>
+        inside(param) {
+          case ArrayParameter(name, tyName, units, length, fill, size, bin) =>
+            name should be ("proton_spectrum_uncerts")
+            tyName should be ("double")
+            units should be ("particles/(sec ster cm^2 keV)")
+            length should be (None)
+            fill should be (Some("-1e31"))
+            size should be (3)
+
+            inside(bin) { case Bin(name, units) =>
+              name should be ("energy")
+              units should be ("keV")
+            }
+          case _ => fail("Decoded to wrong parameter type.")
+        }
+      }
+    }
+  }
+
+  it should "reject parameters with multiple bins" in {
+    withJsonResource("data/hapi-parameter-array-multiple-bins.json") {
+      doesNotDecodeAs[Parameter](_)("Failed to reject invalid parameter.")
+    }
+  }
+}


### PR DESCRIPTION
Adds the HAPI reader, supporting code, and tests.

Some particularly interesting things to look at:
- The HAPI data types (`Bin`, `Info`, and the `Parameter` ADT) and their Circe `Decoder` instances.
- The `JsonDecoderSpec` ScalaTest base class.
- The `foldM` in `HapiReader.toModel`.