### PR TITLE
Refactor HapiBinaryAdapter to extend HapiAdapter

### DIFF
--- a/src/main/scala/latis/input/BinaryAdapter.scala
+++ b/src/main/scala/latis/input/BinaryAdapter.scala
@@ -65,13 +65,13 @@ class BinaryAdapter(model: DataType) extends StreamingAdapter[Array[Byte]] {
     
     model.getScalars.map { s => 
       s("type") match {
-        case Some("int")    => Data(buffer.getInt)
-        case Some("double") => Data(buffer.getDouble)
+        case Some("int")    => Data.IntValue(buffer.getInt)
+        case Some("double") => Data.DoubleValue(buffer.getDouble)
         case Some("string") => 
           val length = bytesToRead(s)
           val bytes = new Array[Byte](length)
           buffer.get(bytes)
-          Data(new String(bytes, StandardCharsets.UTF_8))
+          Data.StringValue(new String(bytes, StandardCharsets.UTF_8))
         case Some(_) => ??? //unsupported type
         case None => ??? //type not defined
       }

--- a/src/main/scala/latis/input/BinaryAdapter.scala
+++ b/src/main/scala/latis/input/BinaryAdapter.scala
@@ -1,0 +1,107 @@
+package latis.input
+
+import java.net.URI
+import java.nio.charset.StandardCharsets
+import java.nio.{ByteBuffer, ByteOrder}
+
+import cats.effect.IO
+import fs2.Stream
+import latis.data.{Data, Sample}
+import latis.model.{DataType, Function, Scalar}
+
+/**
+ * Adapter for parsing HAPI binary data.
+ */
+class BinaryAdapter(model: DataType) extends StreamingAdapter[Array[Byte]] {
+  
+  val order = ByteOrder.LITTLE_ENDIAN //all numeric values are little endian (LSB)
+  
+  lazy val blockSize: Int = model.getScalars.map(bytesToRead).sum
+
+  /**
+   * Provides a Stream of records as Arrays of bytes.
+   */
+  def recordStream(uri: URI): Stream[IO, Array[Byte]] =
+    StreamSource.getStream(uri)
+      .chunkN(blockSize)
+      .map(_.toArray)
+  
+  /**
+   * Parses a record into a Sample. 
+   * Returns None if the record is invalid.
+   */
+  def parseRecord(record: Array[Byte]): Option[Sample] = {
+    // We assume one value for each scalar in the model.
+    // Note that Samples don't capture nested tuple structure.
+    // Assume uncurried model (no nested function), for now.
+    /*
+     * TODO: Traverse the model to build nested functions (Function in range) 
+     * should we apply currying logic or require operation? 
+     * curry should be cheap for ordered data
+     */
+
+    // Get Vectors of domain and range Scalar types.
+    val (dtypes, rtypes) = model match {
+      case Function(d, r) => (d.getScalars, r.getScalars)
+      case _ => (Vector.empty, model.getScalars)
+    }
+
+    // Extract the data values from the record
+    // and split into Vectors of domain and range.
+    val data = extractData(record)
+    val (ds, rs) = data.splitAt(dtypes.length)
+
+    // Construct a Sample from the domain and range values.
+    if (rtypes.length != rs.length) None //invalid record
+    else 
+      Some(Sample(ds, rs))
+  }
+
+  /**
+   * Extracts the data values from the given record as a List.
+   */
+  private def extractData(record: Array[Byte]): List[Data] = {
+    val buffer = ByteBuffer.wrap(record).order(order)
+    
+    model.getScalars.map { s => 
+      s("type") match {
+        case Some("int")    => Data(buffer.getInt)
+        case Some("double") => Data(buffer.getDouble)
+        case Some("string") => 
+          val length = bytesToRead(s)
+          val bytes = new Array[Byte](length)
+          buffer.get(bytes)
+          Data(new String(bytes, StandardCharsets.UTF_8))
+        case Some(_) => ??? //unsupported type
+        case None => ??? //type not defined
+      }
+    }
+  }
+
+  /**
+   * Gets the number of bytes to read for the given scalar
+   * according to the HAPI specification.
+   * 
+   * Note that floating point values are always IEEE 754 
+   * double precision values.
+   * 
+   * Parameters of type string and isotime have a "length" 
+   * specified in the info header that indicates how many bytes 
+   * to read for each string value.
+   */
+  private def bytesToRead(s: Scalar): Int = {
+    s("type") match {
+      case Some("short")  => 2
+      case Some("int")    => 4
+      case Some("long")   => 8
+      case Some("float")  => 8 //not 4
+      case Some("double") => 8
+      case Some("string") => s("length") match {
+        case Some(l) => l.toInt //TODO: this conversion can fail
+        case None => ??? //cannot determine number of bytes to read
+      }
+      case Some(_) => ??? //unsupported type
+      case None => ??? //type not defined
+    }
+  }
+}

--- a/src/main/scala/latis/input/BinaryAdapter.scala
+++ b/src/main/scala/latis/input/BinaryAdapter.scala
@@ -82,19 +82,13 @@ class BinaryAdapter(model: DataType) extends StreamingAdapter[Array[Byte]] {
    * Gets the number of bytes to read for the given scalar
    * according to the HAPI specification.
    * 
-   * Note that floating point values are always IEEE 754 
-   * double precision values.
-   * 
    * Parameters of type string and isotime have a "length" 
    * specified in the info header that indicates how many bytes 
    * to read for each string value.
    */
   private def bytesToRead(s: Scalar): Int = {
     s("type") match {
-      case Some("short")  => 2
       case Some("int")    => 4
-      case Some("long")   => 8
-      case Some("float")  => 8 //not 4
       case Some("double") => 8
       case Some("string") => s("length") match {
         case Some(l) => l.toInt //TODO: this conversion can fail

--- a/src/main/scala/latis/input/HapiBinaryAdapter.scala
+++ b/src/main/scala/latis/input/HapiBinaryAdapter.scala
@@ -34,6 +34,3 @@ object HapiBinaryAdapter extends AdapterFactory {
 
 
 }
-
-
-

--- a/src/main/scala/latis/input/HapiBinaryAdapter.scala
+++ b/src/main/scala/latis/input/HapiBinaryAdapter.scala
@@ -1,122 +1,39 @@
 package latis.input
 
-import java.net.URI
-import java.nio.charset.StandardCharsets
-import java.nio.{ByteBuffer, ByteOrder}
-
-import cats.effect.IO
-import fs2.Stream
-import latis.data.{Data, Sample}
-import latis.model.{DataType, Function, Scalar}
+import latis.model.DataType
 
 /**
- * Adapter for HAPI binary datasets.
+ * Adapts a HAPI service as a source of data
+ * using the binary output option.
  */
-class HapiBinaryAdapter(model: DataType) extends StreamingAdapter[Array[Byte]] {
-  
-  val order = ByteOrder.LITTLE_ENDIAN //all numeric values are little endian (LSB)
-  
-  lazy val blockSize: Int = model.getScalars.map(bytesToRead).sum
+class HapiBinaryAdapter(model: DataType, config: HapiAdapter.Config)
+  extends HapiAdapter(model, config) {
 
   /**
-   * Provides a Stream of records as Arrays of bytes.
+   * Defines the Adapter that will be used to parse the
+   * results from the HAPI service call
    */
-  def recordStream(uri: URI): Stream[IO, Array[Byte]] =
-    StreamSource.getStream(uri)
-      .chunkN(blockSize)
-      .map(_.toArray)
-  
-  /**
-   * Parses a record into a Sample. 
-   * Returns None if the record is invalid.
-   */
-  def parseRecord(record: Array[Byte]): Option[Sample] = {
-    // We assume one value for each scalar in the model.
-    // Note that Samples don't capture nested tuple structure.
-    // Assume uncurried model (no nested function), for now.
-    /*
-     * TODO: Traverse the model to build nested functions (Function in range) 
-     * should we apply currying logic or require operation? 
-     * curry should be cheap for ordered data
-     */
-
-    // Get Vectors of domain and range Scalar types.
-    val (dtypes, rtypes) = model match {
-      case Function(d, r) => (d.getScalars, r.getScalars)
-      case _ => (Vector.empty, model.getScalars)
-    }
-
-    // Extract the data values from the record
-    // and split into Vectors of domain and range.
-    val data = extractData(record)
-    val (ds, rs) = data.splitAt(dtypes.length)
-
-    // Construct a Sample from the domain and range values.
-    if (rtypes.length != rs.length) None //invalid record
-    else 
-      Some(Sample(ds, rs))
-  }
+  def parsingAdapter: Adapter = new BinaryAdapter(model)
 
   /**
-   * Extracts the data values from the given record as a List.
+   * Defines the requested data format.
+   * This must be consistent with the parsingAdapter.
    */
-  private def extractData(record: Array[Byte]): List[Data] = {
-    val buffer = ByteBuffer.wrap(record).order(order)
-    
-    model.getScalars.map { s => 
-      s("type") match {
-        case Some("int")    => Data(buffer.getInt)
-        case Some("double") => Data(buffer.getDouble)
-        case Some("string") => 
-          val length = bytesToRead(s)
-          val bytes = new Array[Byte](length)
-          buffer.get(bytes)
-          Data(new String(bytes, StandardCharsets.UTF_8))
-        case Some(_) => ??? //unsupported type
-        case None => ??? //type not defined
-      }
-    }
-  }
-
-  /**
-   * Gets the number of bytes to read for the given scalar
-   * according to the HAPI specification.
-   * 
-   * Note that floating point values are always IEEE 754 
-   * double precision values.
-   * 
-   * Parameters of type string and isotime have a "length" 
-   * specified in the info header that indicates how many bytes 
-   * to read for each string value.
-   */
-  private def bytesToRead(s: Scalar): Int = {
-    s("type") match {
-      case Some("short")  => 2
-      case Some("int")    => 4
-      case Some("long")   => 8
-      case Some("float")  => 8 //not 4
-      case Some("double") => 8
-      case Some("string") => s("length") match {
-        case Some(l) => l.toInt //TODO: this conversion can fail
-        case None => ??? //cannot determine number of bytes to read
-      }
-      case Some(_) => ??? //unsupported type
-      case None => ??? //type not defined
-    }
-  }
+  def datasetFormat: String = "binary"
 }
 
 //=============================================================================
 
 object HapiBinaryAdapter extends AdapterFactory {
 
-  def apply(model: DataType): HapiBinaryAdapter =
-    new HapiBinaryAdapter(model)
-
   /**
    * Constructor used by the AdapterFactory.
    */
-  def apply(model: DataType, config: AdapterConfig): HapiBinaryAdapter =
-    new HapiBinaryAdapter(model)
+  def apply(model: DataType, config: AdapterConfig): HapiAdapter =
+    new HapiBinaryAdapter(model, new HapiAdapter.Config(config.properties: _*))
+
 
 }
+
+
+

--- a/src/test/scala/latis/input/HapiBinaryAdapterSpec.scala
+++ b/src/test/scala/latis/input/HapiBinaryAdapterSpec.scala
@@ -21,7 +21,7 @@ class HapiBinaryAdapterSpec extends FlatSpec {
         Scalar(Metadata("id" -> "dBrms", "type" -> "double"))
       )
     )
-    def adapter = new HapiBinaryAdapter(model)
+    def adapter = new BinaryAdapter(model)
   }
 
   val ds = reader.getDataset


### PR DESCRIPTION
## Changes
`HapiBinaryAdapter` now extends `HapiAdapter`. This is just like the change to `HapiJsonAdapter`.

## Testing
`HapiBinaryAdapterSpec` now tests with just the parser (`BinaryAdapter`). That's all I changed in the tests.