### PR TITLE
Update BinaryAdapter

### DIFF
--- a/src/main/scala/latis/input/BinaryAdapter.scala
+++ b/src/main/scala/latis/input/BinaryAdapter.scala
@@ -6,7 +6,7 @@ import java.nio.{ByteBuffer, ByteOrder}
 
 import cats.effect.IO
 import fs2.Stream
-import latis.data.{Data, Sample}
+import latis.data.{Data, Datum, Sample}
 import latis.model.{DataType, Function, Scalar}
 
 /**
@@ -60,7 +60,7 @@ class BinaryAdapter(model: DataType) extends StreamingAdapter[Array[Byte]] {
   /**
    * Extracts the data values from the given record as a List.
    */
-  private def extractData(record: Array[Byte]): List[Data] = {
+  private def extractData(record: Array[Byte]): List[Datum] = {
     val buffer = ByteBuffer.wrap(record).order(order)
     
     model.getScalars.map { s => 

--- a/src/test/scala/latis/input/HapiBinaryAdapterSpec.scala
+++ b/src/test/scala/latis/input/HapiBinaryAdapterSpec.scala
@@ -11,9 +11,9 @@ import org.scalatest.Matchers._
 
 class HapiBinaryAdapterSpec extends FlatSpec {
 
+  val uri: URI = FileUtils.resolvePath("data/hapi_binary_data").get.toUri
+
   val reader = new AdaptedDatasetReader {
-    //def uri: URI = new URI("https://cdaweb.gsfc.nasa.gov/hapi/data?id=AC_H0_MFI&time.min=2019-01-01&time.max=2019-01-02&parameters=Magnitude,dBrms&format=binary")
-    def uri: URI = FileUtils.resolvePath("data/hapi_binary_data").get.toUri
     def model: DataType = Function(
       Scalar(Metadata("id" -> "Time", "type" -> "string", "length" -> "24")),
       Tuple(
@@ -21,10 +21,13 @@ class HapiBinaryAdapterSpec extends FlatSpec {
         Scalar(Metadata("id" -> "dBrms", "type" -> "double"))
       )
     )
+
+    def metadata = Metadata("hapi_binary")
+
     def adapter = new BinaryAdapter(model)
   }
 
-  val ds = reader.getDataset
+  val ds = reader.read(uri)
 
   "The first sample in the HAPI Binary dataset" should "contain the correct values" in {
     StreamUtils.unsafeHead(ds.samples) match {


### PR DESCRIPTION
Some stuff changed in LaTiS 3 that broke many things.

This PR fixes `BinaryAdapter` and its tests, but other stuff is still broken. If you want to test that this works, you'll have to comment out the broken things.

See #11.