### PR TITLE
Fix CSV adapter test

### DIFF
--- a/src/test/scala/latis/input/HapiCsvAdapterSpec.scala
+++ b/src/test/scala/latis/input/HapiCsvAdapterSpec.scala
@@ -85,6 +85,6 @@ class HapiCsvAdapterSpec extends FlatSpec {
   "A HapiAdapter" should "get the default time range from the info" in {
     val ds = dataset //Dataset.fromName("sorce_tsi")
       .withOperation(Selection("time", "<", "1611"))
-    ds.unsafeForce.data.samples.length should be (1)
+    ds.unsafeForce.data.length should be (1)
   }
 }


### PR DESCRIPTION
Some stuff changed in LaTiS 3 that broke many things.

This PR fixes the CSV adapter tests, but other stuff is still broken. If you want to test that this works, you'll have to comment out the broken things.