### PR TITLE
Revive latis3-hapi

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,10 +5,7 @@ val latisVersion      = "322efe5e"
 val circeVersion      = "0.13.0"
 val http4sVersion     = "0.21.22"
 
-//lazy val `latis3-core` = ProjectRef(file("../latis3"), "core")
-
 lazy val hapi = (project in file("."))
-//  .dependsOn(`latis3-core`)
   .settings(commonSettings)
   .settings(
     name := "latis3-hapi",

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 ThisBuild / organization := "io.latis-data"
 ThisBuild / scalaVersion := "2.13.5"
 
-val latisVersion      = "322efe5e"
+val latisVersion      = "91b09198"
 val circeVersion      = "0.13.0"
 val http4sVersion     = "0.21.22"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,30 +1,33 @@
 ThisBuild / organization := "io.latis-data"
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.13.5"
 
-//val latisVersion    = "3.0.0-SNAPSHOT"
-val circeVersion      = "0.12.3"
-val http4sVersion     = "0.20.13"
+val latisVersion      = "322efe5e"
+val circeVersion      = "0.13.0"
+val http4sVersion     = "0.21.22"
 
-lazy val `latis3-core` = ProjectRef(file("../latis3"), "core")
+//lazy val `latis3-core` = ProjectRef(file("../latis3"), "core")
 
 lazy val hapi = (project in file("."))
-  .dependsOn(`latis3-core`)
+//  .dependsOn(`latis3-core`)
   .settings(commonSettings)
   .settings(
     name := "latis3-hapi",
     libraryDependencies ++= Seq(
-      // "io.latis-data"           %% "latis-core"      % latisVersion,
-      "org.http4s"             %% "http4s-blaze-client" % http4sVersion,
-      "org.http4s" %% "http4s-circe"        % http4sVersion,
-      "io.circe" %% "circe-core"   % circeVersion,
-      "io.circe" %% "circe-parser" % circeVersion
+      "com.github.latis-data.latis3" %% "latis3-core"         % latisVersion,
+      "org.http4s"                   %% "http4s-blaze-client" % http4sVersion,
+      "org.http4s"                   %% "http4s-circe"        % http4sVersion,
+      "io.circe"                     %% "circe-core"          % circeVersion,
+      "io.circe"                     %% "circe-parser"        % circeVersion
+    ),
+    resolvers ++= Seq(
+      "jitpack" at "https://jitpack.io"
     )
   )
   
 lazy val commonSettings = compilerFlags ++ Seq(
   libraryDependencies ++= Seq(
     "com.typesafe"    % "config"      % "1.3.4",
-    "org.scalatest"  %% "scalatest"   % "3.0.5" % Test
+    "org.scalatest"  %% "scalatest"   % "3.0.9" % Test
   )
 )
 
@@ -33,8 +36,7 @@ lazy val compilerFlags = Seq(
     "-deprecation",
     "-encoding", "utf-8",
     "-feature",
-    "-language:higherKinds",
-    "-Ypartial-unification"
+    "-language:higherKinds"
   ),
   Compile / compile / scalacOptions ++= Seq(
     "-unchecked",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.5.0

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.0
+sbt.version=1.5.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.2.1")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/src/main/scala/latis/input/HapiAdapter.scala
+++ b/src/main/scala/latis/input/HapiAdapter.scala
@@ -12,7 +12,7 @@ import latis.ops.Selection
 import latis.time.TimeFormat
 import latis.util.ConfigLike
 import latis.util.dap2.parser.ast._
-import latis.util.Identifier.IdentifierStringContext
+import latis.util.Identifier
 import latis.util.LatisException
 import latis.util.NetUtils
 import latis.util.hapi.Info
@@ -67,7 +67,7 @@ abstract class HapiAdapter(model: DataType, config: HapiAdapter.Config) extends 
    * Operation.
    */
   override def canHandleOperation(op: Operation): Boolean = op match {
-    case Selection(id, _, _) if id == id"time" => true
+    case Selection(Identifier("time"), _, _) => true
     //case p: Projection => true
     case _ => false
   }
@@ -83,7 +83,7 @@ abstract class HapiAdapter(model: DataType, config: HapiAdapter.Config) extends 
 
     // Updates query info based on each Operation
     ops.foreach {
-      case Selection(id, op, value) if id == id"time" =>
+      case Selection(Identifier("time"), op, value) =>
         val time = TimeFormat.parseIso(value).getOrElse {
           val msg = s"Failed to parse time: $value"
           throw LatisException(msg)

--- a/src/main/scala/latis/input/HapiAdapter.scala
+++ b/src/main/scala/latis/input/HapiAdapter.scala
@@ -41,7 +41,9 @@ abstract class HapiAdapter(model: DataType, config: HapiAdapter.Config) extends 
   private var baseUriString: String = _
 
   /** Defines the format of time strings used by the HAPI API. */
-  private val timeFormat: TimeFormat = TimeFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+  private val timeFormat: TimeFormat = TimeFormat.fromExpression("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    .fold(throw _, identity) //Should be safe
+
 
   /**
    * Applies the given Operations by building and appending

--- a/src/main/scala/latis/input/HapiAdapter.scala
+++ b/src/main/scala/latis/input/HapiAdapter.scala
@@ -12,7 +12,6 @@ import latis.ops.Selection
 import latis.time.TimeFormat
 import latis.util.ConfigLike
 import latis.util.dap2.parser.ast._
-import latis.util.Identifier._
 import latis.util.Identifier.IdentifierStringContext
 import latis.util.LatisException
 import latis.util.NetUtils

--- a/src/main/scala/latis/input/HapiAdapter.scala
+++ b/src/main/scala/latis/input/HapiAdapter.scala
@@ -41,7 +41,7 @@ abstract class HapiAdapter(model: DataType, config: HapiAdapter.Config) extends 
   private var baseUriString: String = _
 
   /** Defines the format of time strings used by the HAPI API. */
-  val timeFormat: TimeFormat = TimeFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'") //TODO: consider relaxing this
+  private val timeFormat: TimeFormat = TimeFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
 
   /**
    * Applies the given Operations by building and appending

--- a/src/main/scala/latis/input/HapiAdapter.scala
+++ b/src/main/scala/latis/input/HapiAdapter.scala
@@ -88,10 +88,10 @@ abstract class HapiAdapter(model: DataType, config: HapiAdapter.Config) extends 
           val msg = s"Failed to parse time: $value"
           throw LatisException(msg)
         } //ms since 1970
-        op match { //TODO: support GtEq and LtEq?
-          case Gt =>
+        op match {
+          case Gt | GtEq =>
             if (time > startTime) startTime = time
-          case Lt =>
+          case Lt | LtEq =>
             if (time < stopTime) stopTime = time
           case Eq =>
             startTime = time

--- a/src/main/scala/latis/input/HapiAdapter.scala
+++ b/src/main/scala/latis/input/HapiAdapter.scala
@@ -41,7 +41,7 @@ abstract class HapiAdapter(model: DataType, config: HapiAdapter.Config) extends 
   private var baseUriString: String = _
 
   /** Defines the format of time strings used by the HAPI API. */
-  val timeFormat: TimeFormat = TimeFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+  val timeFormat: TimeFormat = TimeFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'") //TODO: consider relaxing this
 
   /**
    * Applies the given Operations by building and appending
@@ -88,7 +88,7 @@ abstract class HapiAdapter(model: DataType, config: HapiAdapter.Config) extends 
           val msg = s"Failed to parse time: $value"
           throw LatisException(msg)
         } //ms since 1970
-        op match {
+        op match { //TODO: support GtEq and LtEq?
           case Gt =>
             if (time > startTime) startTime = time
           case Lt =>
@@ -157,8 +157,8 @@ abstract class HapiAdapter(model: DataType, config: HapiAdapter.Config) extends 
   def defaultTimeCoverage(): (Long, Long) = {
     val info = readInfo()
     val either = for {
-      start <- timeFormat.parse(info.startDate)
-      stop  <- timeFormat.parse(info.stopDate)
+      start <- TimeFormat.parseIso(info.startDate)
+      stop  <- TimeFormat.parseIso(info.stopDate)
     } yield (start, stop)
     either.getOrElse {
       val msg = "Failed to get time coverage from HAPI info"

--- a/src/main/scala/latis/input/HapiReader.scala
+++ b/src/main/scala/latis/input/HapiReader.scala
@@ -128,7 +128,7 @@ class HapiReader {
     // must share the same domain. (We check this by comparing the
     // name of the next parameter's bin to the name of the domain
     // of the function.)
-    case (Function(d: Scalar, r), p: ArrayParameter) if p.bin.name == d.id =>
+    case (Function(d: Scalar, r), p: ArrayParameter) if p.bin.name == d.id.fold("")(_.asString) =>
       val np = ScalarParameter(p.name, p.typeName, p.units, p.length, p.fill)
       val newRange = addParameterToModel(r, np)
       newRange.map(Function(d, _))

--- a/src/test/scala/latis/input/HapiBinaryAdapterSpec.scala
+++ b/src/test/scala/latis/input/HapiBinaryAdapterSpec.scala
@@ -2,10 +2,16 @@ package latis.input
 
 import java.net.URI
 
-import latis.data.{DomainData, RangeData, Real, Sample, Text}
+import latis.data.DomainData
+import latis.data.RangeData
+import latis.data.Real
+import latis.data.Sample
+import latis.data.Text
 import latis.metadata.Metadata
 import latis.model._
-import latis.util.{FileUtils, StreamUtils}
+import latis.util.FileUtils
+import latis.util.StreamUtils
+import latis.util.Identifier.IdentifierStringContext
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers._
 
@@ -22,7 +28,7 @@ class HapiBinaryAdapterSpec extends FlatSpec {
       )
     )
 
-    def metadata = Metadata("hapi_binary")
+    def metadata = Metadata(id"hapi_binary")
 
     def adapter = new BinaryAdapter(model)
   }

--- a/src/test/scala/latis/input/HapiCsvAdapterSpec.scala
+++ b/src/test/scala/latis/input/HapiCsvAdapterSpec.scala
@@ -11,7 +11,6 @@ import latis.data.Real
 import latis.data.Sample
 import latis.data.Text
 import latis.dataset.AdaptedDataset
-import latis.dataset.Dataset
 import latis.metadata.Metadata
 import latis.model._
 import latis.model.Scalar
@@ -38,7 +37,7 @@ class HapiCsvAdapterSpec extends FlatSpec {
       )
     )
 
-    val baseUri = new URI("http://lasp.colorado.edu/lisird/hapi/")
+    val baseUri = new URI("https://lasp.colorado.edu/lisird/hapi/")
 
     new AdaptedDataset(Metadata(id"nrl2_tsi_P1Y"), model, adapter, baseUri)
   }
@@ -86,7 +85,7 @@ class HapiCsvAdapterSpec extends FlatSpec {
   }
 
   "A HapiAdapter" should "get the default time range from the info" in {
-    val ds = dataset //Dataset.fromName("sorce_tsi")
+    val ds = dataset
       .withOperation(Selection(id"time", Lt, "1611"))
     ds.unsafeForce.data.length should be (1)
   }

--- a/src/test/scala/latis/input/HapiCsvAdapterSpec.scala
+++ b/src/test/scala/latis/input/HapiCsvAdapterSpec.scala
@@ -16,7 +16,10 @@ import latis.metadata.Metadata
 import latis.model._
 import latis.model.Scalar
 import latis.ops.Selection
-import latis.util.{FdmlUtils, StreamUtils}
+import latis.util.dap2.parser.ast._
+import latis.util.FdmlUtils
+import latis.util.StreamUtils
+import latis.util.Identifier.IdentifierStringContext
 import latis.time.Time
 import latis.output.TextWriter
 
@@ -37,14 +40,14 @@ class HapiCsvAdapterSpec extends FlatSpec {
 
     val baseUri = new URI("http://lasp.colorado.edu/lisird/hapi/")
 
-    new AdaptedDataset(Metadata("nrl2_tsi_P1Y"), model, adapter, baseUri)
+    new AdaptedDataset(Metadata(id"nrl2_tsi_P1Y"), model, adapter, baseUri)
   }
 
 
   "A hapi csv request with time selections" should "return csv records" in {
     val ds = dataset
-      .withOperation(Selection("time", ">", "2010-01-01"))
-      .withOperation(Selection("time", "<", "2011-01-01"))
+      .withOperation(Selection(id"time", Gt, "2010-01-01"))
+      .withOperation(Selection(id"time", Lt, "2011-01-01"))
 
     StreamUtils.unsafeHead(ds.samples) match {
       case Sample(DomainData(Text(time)), RangeData(Real(tsi))) =>
@@ -60,7 +63,7 @@ class HapiCsvAdapterSpec extends FlatSpec {
       Time(Metadata("id" -> "time", "type" -> "string", "units" -> "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")),
       Tuple(
         Scalar(Metadata("id" -> "A", "type" -> "double")),
-        Tuple(Metadata("V"),
+        Tuple(Metadata(id"V"),
           Scalar(Metadata("id" -> "V._1", "type" -> "double")),
           Scalar(Metadata("id" -> "V._2", "type" -> "double")),
           Scalar(Metadata("id" -> "V._3", "type" -> "double")),
@@ -84,7 +87,7 @@ class HapiCsvAdapterSpec extends FlatSpec {
 
   "A HapiAdapter" should "get the default time range from the info" in {
     val ds = dataset //Dataset.fromName("sorce_tsi")
-      .withOperation(Selection("time", "<", "1611"))
+      .withOperation(Selection(id"time", Lt, "1611"))
     ds.unsafeForce.data.length should be (1)
   }
 }

--- a/src/test/scala/latis/input/HapiReaderSpec.scala
+++ b/src/test/scala/latis/input/HapiReaderSpec.scala
@@ -10,6 +10,8 @@ import latis.dataset.Dataset
 import latis.model._
 import latis.ops.Selection
 import latis.time.Time
+import latis.util.dap2.parser.ast._
+import latis.util.Identifier.IdentifierStringContext
 import latis.util.StreamUtils
 import latis.util.hapi._
 
@@ -22,8 +24,8 @@ class HapiReaderSpec extends FlatSpec with Matchers {
 
     val ds = reader.read(uri)
       .getOrElse(fail("Did not get dataset."))
-      .withOperation(Selection("time >= 2010"))
-      .withOperation(Selection("time <  2011"))
+      .withOperation(Selection(id"time", GtEq, "2010"))
+      .withOperation(Selection(id"time", Lt,  "2011"))
 
     ds.id should be ("nrl2_tsi_P1Y")
 

--- a/src/test/scala/latis/input/HapiReaderSpec.scala
+++ b/src/test/scala/latis/input/HapiReaderSpec.scala
@@ -6,7 +6,6 @@ import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 
 import latis.data._
-import latis.dataset.Dataset
 import latis.model._
 import latis.ops.Selection
 import latis.time.Time
@@ -20,20 +19,20 @@ class HapiReaderSpec extends FlatSpec with Matchers {
   val reader = new HapiReader()
 
   "A HAPI reader" should "read a dataset from a HAPI service" in {
-    val uri = new URI("http://lasp.colorado.edu/lisird/hapi/info?id=nrl2_tsi_P1Y")
+    val uri = new URI("https://lasp.colorado.edu/lisird/hapi/info?id=nrl2_tsi_P1Y")
 
     val ds = reader.read(uri)
       .getOrElse(fail("Did not get dataset."))
-      .withOperation(Selection(id"time", GtEq, "2010"))
+      .withOperation(Selection(id"time", Gt, "2010"))
       .withOperation(Selection(id"time", Lt,  "2011"))
 
-    ds.id should be ("nrl2_tsi_P1Y")
+    ds.id.get should be (id"nrl2_tsi_P1Y")
 
     ds.model match {
       case Function(d: Scalar, Tuple(i: Scalar, u: Scalar)) =>
-        d.id should be ("time")
-        i.id should be ("irradiance")
-        u.id should be ("uncertainty")
+        d.id.get should be (id"time")
+        i.id.get should be (id"irradiance")
+        u.id.get should be (id"uncertainty")
     }
 
     StreamUtils.unsafeHead(ds.samples) match {
@@ -47,7 +46,7 @@ class HapiReaderSpec extends FlatSpec with Matchers {
   it should "support scalar timeseries datasets" in {
     val parameters: List[Parameter] = List(
       ScalarParameter("time", "isotime", "UTC", Option(24), None),
-      ScalarParameter("x", "type", "units", None, None)
+      ScalarParameter("x", "string", "units", None, None)
     )
 
     val model: DataType = reader.toModel(parameters).getOrElse(
@@ -56,8 +55,8 @@ class HapiReaderSpec extends FlatSpec with Matchers {
 
     model match {
       case Function(d: Time, r: Scalar) =>
-        d.id should be ("time")
-        r.id should be ("x")
+        d.id.get should be (id"time")
+        r.id.get should be (id"x")
       case _ => fail(s"Unexpected model: $model")
     }
   }
@@ -65,7 +64,7 @@ class HapiReaderSpec extends FlatSpec with Matchers {
   it should "support vector timeseries datasets" in {
     val parameters: List[Parameter] = List(
       ScalarParameter("time", "isotime", "UTC", Option(24), None),
-      VectorParameter("x", "type", "units", None, None, 3)
+      VectorParameter("x", "string", "units", None, None, 3)
     )
 
     val model: DataType = reader.toModel(parameters).getOrElse(
@@ -74,10 +73,10 @@ class HapiReaderSpec extends FlatSpec with Matchers {
 
     model match {
       case Function(d: Time, Tuple(x0, x1, x2)) =>
-        d.id should be ("time")
-        x0.id should be ("x._0")
-        x1.id should be ("x._1")
-        x2.id should be ("x._2")
+        d.id.get should be (id"time")
+        x0.id.get should be (id"x._0")
+        x1.id.get should be (id"x._1")
+        x2.id.get should be (id"x._2")
       case _ => fail(s"Unexpected model: $model")
     }
   }
@@ -85,10 +84,10 @@ class HapiReaderSpec extends FlatSpec with Matchers {
   it should "support scalars and vectors in datasets" in {
     val parameters: List[Parameter] = List(
       ScalarParameter("time", "isotime", "UTC", Option(24), None),
-      ScalarParameter("w", "type", "units", None, None),
-      VectorParameter("x", "type", "units", None, None, 2),
-      VectorParameter("y", "type", "units", None, None, 2),
-      ScalarParameter("z", "type", "units", None, None)
+      ScalarParameter("w", "string", "units", None, None),
+      VectorParameter("x", "string", "units", None, None, 2),
+      VectorParameter("y", "string", "units", None, None, 2),
+      ScalarParameter("z", "string", "units", None, None)
     )
 
     val model: DataType = reader.toModel(parameters).getOrElse(
@@ -97,13 +96,13 @@ class HapiReaderSpec extends FlatSpec with Matchers {
 
     model match {
       case Function(d: Time, Tuple(w, Tuple(x0, x1), Tuple(y0, y1), z)) =>
-        d.id should be ("time")
-        w.id should be ("w")
-        x0.id should be ("x._0")
-        x1.id should be ("x._1")
-        y0.id should be ("y._0")
-        y1.id should be ("y._1")
-        z.id should be ("z")
+        d.id.get should be (id"time")
+        w.id.get should be (id"w")
+        x0.id.get should be (id"x._0")
+        x1.id.get should be (id"x._1")
+        y0.id.get should be (id"y._0")
+        y1.id.get should be (id"y._1")
+        z.id.get should be (id"z")
       case _ => fail(s"Unexpected model: $model")
     }
   }
@@ -111,8 +110,8 @@ class HapiReaderSpec extends FlatSpec with Matchers {
   it should "support datasets with a vector as the first non-time parameter" in {
     val parameters: List[Parameter] = List(
       ScalarParameter("time", "isotime", "UTC", Option(24), None),
-      VectorParameter("x", "type", "units", None, None, 2),
-      ScalarParameter("y", "type", "units", None, None)
+      VectorParameter("x", "string", "units", None, None, 2),
+      ScalarParameter("y", "string", "units", None, None)
     )
 
     val model: DataType = reader.toModel(parameters).getOrElse(
@@ -121,10 +120,10 @@ class HapiReaderSpec extends FlatSpec with Matchers {
 
     model match {
       case Function(d: Time, Tuple(Tuple(x0, x1), y)) =>
-        d.id should be ("time")
-        x0.id should be ("x._0")
-        x1.id should be ("x._1")
-        y.id should be ("y")
+        d.id.get should be (id"time")
+        x0.id.get should be (id"x._0")
+        x1.id.get should be (id"x._1")
+        y.id.get should be (id"y")
       case _ => fail(s"Unexpected model: $model")
     }
   }
@@ -132,7 +131,7 @@ class HapiReaderSpec extends FlatSpec with Matchers {
   it should "support array parameters in datasets" in {
     val parameters: List[Parameter] = List(
       ScalarParameter("time", "isotime", "UTC", Option(24), None),
-      ArrayParameter("x", "type", "units", None, None, 1,
+      ArrayParameter("x", "string", "units", None, None, 1,
         Bin("w", "units")
       )
     )
@@ -143,9 +142,9 @@ class HapiReaderSpec extends FlatSpec with Matchers {
 
     model match {
       case Function(d: Time, Function(w: Scalar, x: Scalar)) =>
-        d.id should be ("time")
-        w.id should be ("w")
-        x.id should be ("x")
+        d.id.get should be (id"time")
+        w.id.get should be (id"w")
+        x.id.get should be (id"x")
       case _ => fail(s"Unexpected model: $model")
     }
   }
@@ -153,13 +152,13 @@ class HapiReaderSpec extends FlatSpec with Matchers {
   it should "support multiple array parameters in datasets" in {
     val parameters: List[Parameter] = List(
       ScalarParameter("time", "isotime", "UTC", Option(24), None),
-      ArrayParameter("x", "type", "units", None, None, 1,
+      ArrayParameter("x", "string", "units", None, None, 1,
         Bin("w", "units")
       ),
-      ArrayParameter("y", "type", "units", None, None, 1,
+      ArrayParameter("y", "string", "units", None, None, 1,
         Bin("w", "units")
       ),
-      ArrayParameter("z", "type", "units", None, None, 1,
+      ArrayParameter("z", "string", "units", None, None, 1,
         Bin("w", "units")
       )
     )
@@ -170,11 +169,11 @@ class HapiReaderSpec extends FlatSpec with Matchers {
 
     model match {
       case Function(d: Time, Function(w: Scalar, Tuple(x: Scalar, y: Scalar, z: Scalar))) =>
-        d.id should be ("time")
-        w.id should be ("w")
-        x.id should be ("x")
-        y.id should be ("y")
-        z.id should be ("z")
+        d.id.get should be (id"time")
+        w.id.get should be (id"w")
+        x.id.get should be (id"x")
+        y.id.get should be (id"y")
+        z.id.get should be (id"z")
       case _ => fail(s"Unexpected model: $model")
     }
   }
@@ -182,10 +181,10 @@ class HapiReaderSpec extends FlatSpec with Matchers {
   it should "gracefully reject mixing array parameters with different bins" in {
     val parameters: List[Parameter] = List(
       ScalarParameter("time", "isotime", "UTC", Option(24), None),
-      ArrayParameter("x", "type", "units", None, None, 1,
+      ArrayParameter("x", "string", "units", None, None, 1,
         Bin("w", "units")
       ),
-      ArrayParameter("y", "type", "units", None, None, 1,
+      ArrayParameter("y", "string", "units", None, None, 1,
         Bin("z", "units")
       )
     )
@@ -196,8 +195,8 @@ class HapiReaderSpec extends FlatSpec with Matchers {
   it should "gracefully reject mixing array and other parameters" in {
     val parameters: List[Parameter] = List(
       ScalarParameter("time", "isotime", "UTC", Option(24), None),
-      ScalarParameter("x", "type", "units", None, None),
-      ArrayParameter("y", "type", "units", None, None, 1,
+      ScalarParameter("x", "string", "units", None, None),
+      ArrayParameter("y", "string", "units", None, None, 1,
         Bin("w", "units")
       )
     )

--- a/src/test/scala/latis/input/TestHapiJsonAdapter.scala
+++ b/src/test/scala/latis/input/TestHapiJsonAdapter.scala
@@ -9,6 +9,8 @@ import latis.output.TextWriter
 import latis.util.FileUtils
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers._
+import latis.util.dap2.parser.ast._
+import latis.util.Identifier.IdentifierStringContext
 import latis.util.StreamUtils
 import latis.dataset.AdaptedDataset
 import latis.ops.Selection
@@ -34,15 +36,15 @@ class TestHapiJsonAdapter extends FlatSpec {
 
     val baseUri = new URI("https://cdaweb.gsfc.nasa.gov/hapi/")
 
-    new AdaptedDataset(Metadata("AC_H0_MFI"), model, adapter, baseUri)
+    new AdaptedDataset(Metadata(id"AC_H0_MFI"), model, adapter, baseUri)
   }
 
   
   "A HapiJsonAdapter" should "read a json response" in {
 
     val ds = dataset
-      .withOperation(Selection("time", ">", "2019-01-01T00:00:01"))
-      .withOperation(Selection("time", "<", "2019-01-01T00:00:15"))
+      .withOperation(Selection(id"time", Gt, "2019-01-01T00:00:01"))
+      .withOperation(Selection(id"time", Lt, "2019-01-01T00:00:15"))
 
     StreamUtils.unsafeHead(ds.samples) match {
       case Sample(DomainData(Text(time)), RangeData(Real(mag), Real(db))) =>


### PR DESCRIPTION
This PR brings a number of fixes and dependency updates to make `latis3-hapi` compatible with the latest `latis3` again. 

I fixed all build errors and failing tests, but stopped short of making everything idiomatic. For example, there are still a lot of places where we're using Strings for names instead of `Identifier` (e.g. `latis.util.hapi.Parameter`). It'll probably be worth a separate ticket to make those improvements. 

This was a yak I had to shave before fixing our `hapi-server` project. Once we merge this I can point `hapi-server` at this new working version.

I'll comment a few design decisions I want to discuss.