### PR TITLE
Hapi 69 Binary Response

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 ThisBuild / organization := "io.latis-data"
 ThisBuild / scalaVersion := "2.13.6"
 
-val latisVersion  = "f9c06477"
+val latisVersion  = "0e670a3"
 val circeVersion  = "0.14.1"
 val http4sVersion = "0.23.1"
 

--- a/src/main/scala/latis/util/hapi/DataCodec.scala
+++ b/src/main/scala/latis/util/hapi/DataCodec.scala
@@ -1,0 +1,47 @@
+package latis.util.hapi
+
+import scodec._
+import scodec.bits._
+
+import latis.data.Data
+import latis.data.Data._
+import latis.model._
+
+/**
+ * The HAPI standard only supports 32-bit little endian integers, little endian
+ * double-precision floats, and length-specified null-padded ASCII strings. For a
+ * LaTiS-based hapiCodec f:Scalar => Codec[Data], this means that only Scalars of
+ * IntValueType, DoubleValueType, and StringValueType are supported, with the numeric
+ * ones being encoded using little endian codecs, and strings being encoded using the
+ * ascii codec with null padding based on the size provided in the Scalar metadata.
+ */
+object DataCodec {
+
+  /*
+   * TODO: replace codecs.fail with Either & LatisExceptions to make failure
+   *  happen before a response is sent from the server
+   */
+  def hapiCodec(s: Scalar): Codec[Data] = s.valueType match {
+    case BooleanValueType => codecs.fail(Err("Boolean not supported."))
+    case ByteValueType    => codecs.fail(Err("Byte not supported."))
+    case ShortValueType   => codecs.fail(Err("Short not supported."))
+    case IntValueType     => codecs.int32L.xmap[IntValue](IntValue, _.value).upcast[Data]
+    case LongValueType    => codecs.fail(Err("Long not supported."))
+    case FloatValueType   => codecs.fail(Err("Float not supported."))
+    case DoubleValueType  => codecs.doubleL.xmap[DoubleValue](DoubleValue, _.value).upcast[Data]
+    case StringValueType if s.metadata.getProperty("size").nonEmpty =>
+      val size = s.metadata.getProperty("size").get.toLong * 8
+      codecs.paddedFixedSizeBits(
+        size,
+        codecs.ascii,
+        codecs.literals.constantBitVectorCodec(BitVector(hex"00"))
+      ).xmap[StringValue](s => StringValue(s.replace("\u0000", "")), _.value).upcast[Data]
+    case StringValueType  => codecs.fail(Err("String without a size defined not supported."))
+    case BinaryValueType  => codecs.fail(Err("Binary blob not supported."))
+    //Note that there is no standard binary encoding for Char, BigInt, or BigDecimal
+    case CharValueType       => codecs.fail(Err("Char not supported."))
+    case BigIntValueType     => codecs.fail(Err("BigInt not supported."))
+    case BigDecimalValueType => codecs.fail(Err("BigDecimal not supported."))
+  }
+
+}

--- a/src/test/scala/latis/util/hapi/HapiBinaryEncoderSpec.scala
+++ b/src/test/scala/latis/util/hapi/HapiBinaryEncoderSpec.scala
@@ -1,0 +1,96 @@
+package latis.util.hapi
+
+import cats.effect.unsafe.implicits.global
+import org.scalatest.EitherValues._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers._
+import scodec.bits._
+import scodec.codecs.implicits._
+import scodec.{Encoder => SEncoder, _}
+
+import latis.data.Data._
+import latis.dataset.Dataset
+import latis.dsl.DatasetGenerator
+import latis.metadata.Metadata
+import latis.model._
+import latis.output.BinaryEncoder
+import latis.util.Identifier.IdentifierStringContext
+
+class HapiBinaryEncoderSpec extends AnyFlatSpec {
+
+  /** Instance of BinaryEncoder for testing. */
+  val enc: BinaryEncoder = new BinaryEncoder(DataCodec.hapiCodec)
+
+  "A Binary encoder" should "encode a dataset to binary" in {
+    val ds: Dataset = DatasetGenerator("x -> (a: int, b: double)")
+    val encodedList = enc.encode(ds).compile.toList.unsafeRunSync()
+
+    val expected = List(
+      SEncoder.encode(0).require.reverseByteOrder ++
+        SEncoder.encode(0).require.reverseByteOrder ++
+        SEncoder.encode(0.0).require.reverseByteOrder,
+      SEncoder.encode(1).require.reverseByteOrder ++
+        SEncoder.encode(1).require.reverseByteOrder ++
+        SEncoder.encode(1.0).require.reverseByteOrder,
+      SEncoder.encode(2).require.reverseByteOrder ++
+        SEncoder.encode(2).require.reverseByteOrder ++
+        SEncoder.encode(2.0).require.reverseByteOrder
+    )
+
+    encodedList should be(expected)
+  }
+
+  "The HAPI data codec's encoder" should "encode ints as 32-bit little-endian integers" in {
+    val d = (3: Int): IntValue
+    val s = Scalar(id"a", IntValueType)
+    val expected = Attempt.successful(BitVector(hex"03000000"))
+    DataCodec.hapiCodec(s).encode(d) should be(expected)
+  }
+
+  it should "encode doubles as 64-bit little-endian doubles" in {
+    val d = (6.6: Double): DoubleValue
+    val s = Scalar(id"a", DoubleValueType)
+    val expected = Attempt.successful(BitVector(hex"6666666666661a40"))
+    DataCodec.hapiCodec(s).encode(d) should be(expected)
+  }
+
+  it should "encode strings as null-padded ASCII" in {
+    val d = "foo": StringValue
+    val s = Scalar.fromMetadata(Metadata("id" -> "a", "type" -> "string", "size" -> "5")).value
+    val expected = Attempt.successful(BitVector(hex"666f6f0000"))
+    DataCodec.hapiCodec(s).encode(d) should be(expected)
+  }
+
+  "The HAPI data codec's decoder" should "decode ints from 32-bit little-endian integers" in {
+    val d = (3: Int): IntValue
+    val s = Scalar(id"a", IntValueType)
+    val encoded = BitVector(hex"03000000")
+    val decoded = DataCodec.hapiCodec(s).decode(encoded) match {
+      case Attempt.Successful(DecodeResult(value, _)) => value
+      case _ => fail("Failed to decode")
+    }
+    decoded should be(d)
+  }
+
+  it should "decode doubles from 64-bit little-endian doubles" in {
+    val d = (6.6: Double): DoubleValue
+    val s = Scalar(id"a", DoubleValueType)
+    val encoded = BitVector(hex"6666666666661a40")
+    val decoded = DataCodec.hapiCodec(s).decode(encoded) match {
+      case Attempt.Successful(DecodeResult(value, _)) => value
+      case _ => fail("Failed to decode")
+    }
+    decoded should be(d)
+  }
+
+  it should "decode strings from null-padded ASCII" in {
+    val d = "foo": StringValue
+    val s = Scalar.fromMetadata(Metadata("id" -> "a", "type" -> "string", "size" -> "5")).value
+    val encoded = BitVector(hex"666f6f0000")
+    val decoded = DataCodec.hapiCodec(s).decode(encoded) match {
+      case Attempt.Successful(DecodeResult(value, _)) => value
+      case _ => fail("Failed to decode")
+    }
+    decoded should be(d)
+  }
+}


### PR DESCRIPTION
Adds the HapiBinaryEncoder which creates a BinaryEncoder from LaTiS with the default dataCodec replaced by one that is HAPI compliant.