### PR TITLE
Incorporate BitVector Stream to Byte Stream from LaTiS 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 ThisBuild / organization := "io.latis-data"
 ThisBuild / scalaVersion := "2.13.6"
 
-val latisVersion  = "0e670a3"
+val latisVersion  = "cbf0c8c"
 val circeVersion  = "0.14.1"
 val http4sVersion = "0.23.1"
 

--- a/src/test/scala/latis/util/hapi/HapiBinaryEncoderSpec.scala
+++ b/src/test/scala/latis/util/hapi/HapiBinaryEncoderSpec.scala
@@ -25,17 +25,18 @@ class HapiBinaryEncoderSpec extends AnyFlatSpec {
     val ds: Dataset = DatasetGenerator("x -> (a: int, b: double)")
     val encodedList = enc.encode(ds).compile.toList.unsafeRunSync()
 
-    val expected = List(
+    val bitVec =
       SEncoder.encode(0).require.reverseByteOrder ++
         SEncoder.encode(0).require.reverseByteOrder ++
-        SEncoder.encode(0.0).require.reverseByteOrder,
+        SEncoder.encode(0.0).require.reverseByteOrder ++
       SEncoder.encode(1).require.reverseByteOrder ++
         SEncoder.encode(1).require.reverseByteOrder ++
-        SEncoder.encode(1.0).require.reverseByteOrder,
+        SEncoder.encode(1.0).require.reverseByteOrder ++
       SEncoder.encode(2).require.reverseByteOrder ++
         SEncoder.encode(2).require.reverseByteOrder ++
         SEncoder.encode(2.0).require.reverseByteOrder
-    )
+
+    val expected = bitVec.toByteArray.toList
 
     encodedList should be(expected)
   }


### PR DESCRIPTION
Updates the LaTiS version used and incorporates the changes to BinaryEncoder Streams in the relevant test here