### PR TITLE
Add support for null units and multi-dimensional size and bins

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
 ThisBuild / organization := "io.latis-data"
 ThisBuild / scalaVersion := "2.13.8"
 
-val latisVersion  = "fd8e35d"
+val latisVersion  = "de6724b"
 val circeVersion  = "0.14.2"
-val http4sVersion = "0.23.14"
+val http4sVersion = "0.23.15"
 
 lazy val hapi = (project in file("."))
   .settings(commonSettings)
@@ -23,7 +23,7 @@ lazy val hapi = (project in file("."))
   
 lazy val commonSettings = Seq(
   libraryDependencies ++= Seq(
-    "com.typesafe"   % "config"              % "1.4.1",
+    "com.typesafe"   % "config"              % "1.4.2",
     "org.scalameta" %% "munit"               % "0.7.29" % Test,
     "org.typelevel" %% "munit-cats-effect-3" % "1.0.7" % Test
   ),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")
-addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.20")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.1")

--- a/src/main/scala/latis/input/HapiReader.scala
+++ b/src/main/scala/latis/input/HapiReader.scala
@@ -2,6 +2,7 @@ package latis.input
 
 import java.net.URI
 
+import cats.data.NonEmptyList
 import cats.effect.IO
 import cats.effect.Resource
 import cats.effect.unsafe.implicits.global
@@ -161,7 +162,7 @@ class HapiReader {
    * This is currently limited to one-dimensional array parameters.
    */
   private def toFunction(p: ArrayParameter): Function = p match {
-    case ArrayParameter(name, tyName, units, length, fill, _, Bin(bName, bUnits) :: Nil) =>
+    case ArrayParameter(name, tyName, units, length, fill, _, NonEmptyList(Bin(bName, bUnits), Nil)) =>
       // The domain of the function is the bin as a Scalar.
       val d: DataType = toScalar(
         ScalarParameter(bName, "double", bUnits.some, None, None)
@@ -188,7 +189,7 @@ class HapiReader {
     case VectorParameter(name, tyName, units, length, fill, size) =>
       // This will flatten a nD VectorParameter to a 1D Tuple.
       // TODO: consider nested Tuples or at least better naming
-      val ds: List[DataType] = List.tabulate(size.product) { n =>
+      val ds: List[DataType] = List.tabulate(size.toList.product) { n =>
         val md = makeMetadata(s"$name._$n", tyName, units, length, fill)
         Scalar.fromMetadata(md).fold(throw _, identity)
       }

--- a/src/main/scala/latis/util/hapi/parameter.scala
+++ b/src/main/scala/latis/util/hapi/parameter.scala
@@ -16,7 +16,7 @@ sealed trait Parameter
 final case class ScalarParameter(
   name: String,
   typeName: String,
-  units: String,
+  units: Option[String],
   length: Option[Int],
   fill: Option[String]
 ) extends Parameter
@@ -25,7 +25,7 @@ final case class ScalarParameter(
 final case class VectorParameter(
   name: String,
   typeName: String,
-  units: String,
+  units: Option[String],
   length: Option[Int],
   fill: Option[String],
   size: Int
@@ -35,7 +35,7 @@ final case class VectorParameter(
 final case class ArrayParameter(
   name: String,
   typeName: String,
-  units: String,
+  units: Option[String], //TODO: could be array of strings
   length: Option[Int],
   fill: Option[String],
   size: Int,
@@ -48,7 +48,7 @@ object Parameter {
     final def apply(c: HCursor): Decoder.Result[Parameter] = for {
       name   <- c.get[String]("name")
       tyName <- c.get[String]("type")
-      units  <- c.get[String]("units")
+      units  <- c.get[Option[String]]("units")
       // Only time and string parameters have length.
       length <- if (tyName == "string" || tyName == "isotime") {
         c.get[Int]("length").map(Option(_))

--- a/src/main/scala/latis/util/hapi/parameter.scala
+++ b/src/main/scala/latis/util/hapi/parameter.scala
@@ -1,5 +1,6 @@
 package latis.util.hapi
 
+import cats.data.NonEmptyList
 import io.circe.Decoder
 import io.circe.DecodingFailure
 import io.circe.HCursor
@@ -28,7 +29,7 @@ final case class VectorParameter(
   units: Option[String],
   length: Option[Int],
   fill: Option[String],
-  size: List[Int]
+  size: NonEmptyList[Int]
 ) extends Parameter
 
 /** Represents a parameter with size and bins. */
@@ -38,8 +39,8 @@ final case class ArrayParameter(
   units: Option[String], //TODO: could be array of strings
   length: Option[Int],
   fill: Option[String],
-  size: List[Int],
-  bin: List[Bin]
+  size: NonEmptyList[Int],
+  bin: NonEmptyList[Bin]
 ) extends Parameter
 
 object Parameter {
@@ -54,7 +55,7 @@ object Parameter {
         c.get[Int]("length").map(Option(_))
       } else Right(None)
       fill   <- c.get[Option[String]]("fill")
-      size   <- c.get[Option[List[Int]]]("size").flatMap {
+      size   <- c.get[Option[NonEmptyList[Int]]]("size").flatMap {
         case Some(s) => Right(Option(s))
         case None    => Right(None)
         case _       => Left(DecodingFailure("Size", c.history))
@@ -62,7 +63,7 @@ object Parameter {
       // There will only be bins if size was defined.
       bins  <- size match {
         //TODO: make sure bins are consistent with size
-        case Some(_) => c.get[Option[List[Bin]]]("bins").flatMap {
+        case Some(_) => c.get[Option[NonEmptyList[Bin]]]("bins").flatMap {
           case Some(b) => Right(Option(b))
           case None    => Right(None)
           case _       => Left(DecodingFailure("Bins", c.history))

--- a/src/test/resources/data/hapi-parameter-array-multiple-bins.json
+++ b/src/test/resources/data/hapi-parameter-array-multiple-bins.json
@@ -1,19 +1,19 @@
 {
-    "name": "FPDU_plasmagram",
+    "name": "foo",
     "type": "double",
-    "units": "cm!e-2!ns!e-1!nsr!e-1!nkeV!e-1!n",
-    "fill": "-1.0E31",
-    "size": [32,31],
+    "units": "m",
+    "fill": null,
+    "size": [2,3],
     "bins": [
         {
-            "name": "FPDU_Alpha",
-            "units": "degrees",
-            "centers": []
+            "name": "x",
+            "units": "m",
+            "centers": [1,2]
         },
         {
-            "name": "FPDU_Energy",
-            "units": "keV",
-            "centers":[]
+            "name": "y",
+            "units": "m",
+            "centers":[1,2,3]
         }
     ]
 }

--- a/src/test/resources/data/hapi-parameter-null-units.json
+++ b/src/test/resources/data/hapi-parameter-null-units.json
@@ -1,0 +1,7 @@
+{
+    "name": "Np",
+    "type": "double",
+    "units": null,
+    "fill": "-1.0E31",
+    "description": "Solar Wind Proton Number Density, scalar"
+}

--- a/src/test/resources/data/hapi-parameter-vector.json
+++ b/src/test/resources/data/hapi-parameter-vector.json
@@ -4,5 +4,5 @@
     "units": "km/s",
     "fill": "-1.0E31",
     "description": "Solar Wind Velocity in GSE coord., 3 components",
-    "size": [3]
+    "size": [3,2]
 }

--- a/src/test/scala/latis/input/HapiReaderSuite.scala
+++ b/src/test/scala/latis/input/HapiReaderSuite.scala
@@ -2,6 +2,7 @@ package latis.input
 
 import java.net.URI
 
+import cats.data.NonEmptyList
 import munit.CatsEffectSuite
 
 import latis.data._
@@ -64,7 +65,7 @@ class HapiReaderSuite extends CatsEffectSuite {
   test("support vector timeseries datasets") {
     val parameters: List[Parameter] = List(
       ScalarParameter("time", "isotime", Option("UTC"), Option(24), None),
-      VectorParameter("x", "string", Option("units"), None, None, List(3))
+      VectorParameter("x", "string", Option("units"), None, None, NonEmptyList.of(3))
     )
 
     reader.toModel(parameters) match {
@@ -83,8 +84,8 @@ class HapiReaderSuite extends CatsEffectSuite {
     val parameters: List[Parameter] = List(
       ScalarParameter("time", "isotime", Option("UTC"), Option(24), None),
       ScalarParameter("w", "string", Option("units"), None, None),
-      VectorParameter("x", "string", Option("units"), None, None, List(2)),
-      VectorParameter("y", "string", Option("units"), None, None, List(2)),
+      VectorParameter("x", "string", Option("units"), None, None, NonEmptyList.of(2)),
+      VectorParameter("y", "string", Option("units"), None, None, NonEmptyList.of(2)),
       ScalarParameter("z", "string", Option("units"), None, None)
     )
 
@@ -105,7 +106,7 @@ class HapiReaderSuite extends CatsEffectSuite {
   test("support datasets with a vector as the first non-time parameter") {
     val parameters: List[Parameter] = List(
       ScalarParameter("time", "isotime", Option("UTC"), Option(24), None),
-      VectorParameter("x", "string", Option("units"), None, None, List(2)),
+      VectorParameter("x", "string", Option("units"), None, None, NonEmptyList.of(2)),
       ScalarParameter("y", "string", Option("units"), None, None)
     )
 
@@ -123,8 +124,8 @@ class HapiReaderSuite extends CatsEffectSuite {
   test("support array parameters in datasets") {
     val parameters: List[Parameter] = List(
       ScalarParameter("time", "isotime", Option("UTC"), Option(24), None),
-      ArrayParameter("x", "string", Option("units"), None, None, List(1),
-        List(Bin("w", "units"))
+      ArrayParameter("x", "string", Option("units"), None, None, NonEmptyList.of(1),
+        NonEmptyList.of(Bin("w", "units"))
       )
     )
 
@@ -141,14 +142,14 @@ class HapiReaderSuite extends CatsEffectSuite {
   test("support multiple array parameters in datasets") {
     val parameters: List[Parameter] = List(
       ScalarParameter("time", "isotime", Option("UTC"), Option(24), None),
-      ArrayParameter("x", "string", Option("units"), None, None, List(1),
-        List(Bin("w", "units"))
+      ArrayParameter("x", "string", Option("units"), None, None, NonEmptyList.of(1),
+        NonEmptyList.of(Bin("w", "units"))
       ),
-      ArrayParameter("y", "string", Option("units"), None, None, List(1),
-        List(Bin("w", "units"))
+      ArrayParameter("y", "string", Option("units"), None, None, NonEmptyList.of(1),
+        NonEmptyList.of(Bin("w", "units"))
       ),
-      ArrayParameter("z", "string", Option("units"), None, None, List(1),
-        List(Bin("w", "units"))
+      ArrayParameter("z", "string", Option("units"), None, None, NonEmptyList.of(1),
+        NonEmptyList.of(Bin("w", "units"))
       )
     )
 
@@ -167,11 +168,11 @@ class HapiReaderSuite extends CatsEffectSuite {
   test("gracefully reject mixing array parameters with different bins") {
     val parameters: List[Parameter] = List(
       ScalarParameter("time", "isotime", Option("UTC"), Option(24), None),
-      ArrayParameter("x", "string", Option("units"), None, None, List(1),
-        List(Bin("w", "units"))
+      ArrayParameter("x", "string", Option("units"), None, None, NonEmptyList.of(1),
+        NonEmptyList.of(Bin("w", "units"))
       ),
-      ArrayParameter("y", "string", Option("units"), None, None, List(1),
-        List(Bin("z", "units"))
+      ArrayParameter("y", "string", Option("units"), None, None, NonEmptyList.of(1),
+        NonEmptyList.of(Bin("z", "units"))
       )
     )
 
@@ -182,8 +183,8 @@ class HapiReaderSuite extends CatsEffectSuite {
     val parameters: List[Parameter] = List(
       ScalarParameter("time", "isotime", Option("UTC"), Option(24), None),
       ScalarParameter("x", "string", Option("units"), None, None),
-      ArrayParameter("y", "string", Option("units"), None, None, List(1),
-        List(Bin("w", "units"))
+      ArrayParameter("y", "string", Option("units"), None, None, NonEmptyList.of(1),
+        NonEmptyList.of(Bin("w", "units"))
       )
     )
 

--- a/src/test/scala/latis/input/HapiReaderSuite.scala
+++ b/src/test/scala/latis/input/HapiReaderSuite.scala
@@ -48,8 +48,8 @@ class HapiReaderSuite extends CatsEffectSuite {
 
   test("support scalar timeseries datasets") {
     val parameters: List[Parameter] = List(
-      ScalarParameter("time", "isotime", "UTC", Option(24), None),
-      ScalarParameter("x", "string", "units", None, None)
+      ScalarParameter("time", "isotime", Option("UTC"), Option(24), None),
+      ScalarParameter("x", "string", Option("units"), None, None)
     )
 
     reader.toModel(parameters) match {
@@ -63,8 +63,8 @@ class HapiReaderSuite extends CatsEffectSuite {
 
   test("support vector timeseries datasets") {
     val parameters: List[Parameter] = List(
-      ScalarParameter("time", "isotime", "UTC", Option(24), None),
-      VectorParameter("x", "string", "units", None, None, 3)
+      ScalarParameter("time", "isotime", Option("UTC"), Option(24), None),
+      VectorParameter("x", "string", Option("units"), None, None, 3)
     )
 
     reader.toModel(parameters) match {
@@ -81,11 +81,11 @@ class HapiReaderSuite extends CatsEffectSuite {
 
   test("support scalars and vectors in datasets") {
     val parameters: List[Parameter] = List(
-      ScalarParameter("time", "isotime", "UTC", Option(24), None),
-      ScalarParameter("w", "string", "units", None, None),
-      VectorParameter("x", "string", "units", None, None, 2),
-      VectorParameter("y", "string", "units", None, None, 2),
-      ScalarParameter("z", "string", "units", None, None)
+      ScalarParameter("time", "isotime", Option("UTC"), Option(24), None),
+      ScalarParameter("w", "string", Option("units"), None, None),
+      VectorParameter("x", "string", Option("units"), None, None, 2),
+      VectorParameter("y", "string", Option("units"), None, None, 2),
+      ScalarParameter("z", "string", Option("units"), None, None)
     )
 
     reader.toModel(parameters) match {
@@ -104,9 +104,9 @@ class HapiReaderSuite extends CatsEffectSuite {
 
   test("support datasets with a vector as the first non-time parameter") {
     val parameters: List[Parameter] = List(
-      ScalarParameter("time", "isotime", "UTC", Option(24), None),
-      VectorParameter("x", "string", "units", None, None, 2),
-      ScalarParameter("y", "string", "units", None, None)
+      ScalarParameter("time", "isotime", Option("UTC"), Option(24), None),
+      VectorParameter("x", "string", Option("units"), None, None, 2),
+      ScalarParameter("y", "string", Option("units"), None, None)
     )
 
     reader.toModel(parameters) match {
@@ -122,8 +122,8 @@ class HapiReaderSuite extends CatsEffectSuite {
 
   test("support array parameters in datasets") {
     val parameters: List[Parameter] = List(
-      ScalarParameter("time", "isotime", "UTC", Option(24), None),
-      ArrayParameter("x", "string", "units", None, None, 1,
+      ScalarParameter("time", "isotime", Option("UTC"), Option(24), None),
+      ArrayParameter("x", "string", Option("units"), None, None, 1,
         Bin("w", "units")
       )
     )
@@ -140,14 +140,14 @@ class HapiReaderSuite extends CatsEffectSuite {
 
   test("support multiple array parameters in datasets") {
     val parameters: List[Parameter] = List(
-      ScalarParameter("time", "isotime", "UTC", Option(24), None),
-      ArrayParameter("x", "string", "units", None, None, 1,
+      ScalarParameter("time", "isotime", Option("UTC"), Option(24), None),
+      ArrayParameter("x", "string", Option("units"), None, None, 1,
         Bin("w", "units")
       ),
-      ArrayParameter("y", "string", "units", None, None, 1,
+      ArrayParameter("y", "string", Option("units"), None, None, 1,
         Bin("w", "units")
       ),
-      ArrayParameter("z", "string", "units", None, None, 1,
+      ArrayParameter("z", "string", Option("units"), None, None, 1,
         Bin("w", "units")
       )
     )
@@ -166,11 +166,11 @@ class HapiReaderSuite extends CatsEffectSuite {
 
   test("gracefully reject mixing array parameters with different bins") {
     val parameters: List[Parameter] = List(
-      ScalarParameter("time", "isotime", "UTC", Option(24), None),
-      ArrayParameter("x", "string", "units", None, None, 1,
+      ScalarParameter("time", "isotime", Option("UTC"), Option(24), None),
+      ArrayParameter("x", "string", Option("units"), None, None, 1,
         Bin("w", "units")
       ),
-      ArrayParameter("y", "string", "units", None, None, 1,
+      ArrayParameter("y", "string", Option("units"), None, None, 1,
         Bin("z", "units")
       )
     )
@@ -180,9 +180,9 @@ class HapiReaderSuite extends CatsEffectSuite {
 
   test("gracefully reject mixing array and other parameters") {
     val parameters: List[Parameter] = List(
-      ScalarParameter("time", "isotime", "UTC", Option(24), None),
-      ScalarParameter("x", "string", "units", None, None),
-      ArrayParameter("y", "string", "units", None, None, 1,
+      ScalarParameter("time", "isotime", Option("UTC"), Option(24), None),
+      ScalarParameter("x", "string", Option("units"), None, None),
+      ArrayParameter("y", "string", Option("units"), None, None, 1,
         Bin("w", "units")
       )
     )
@@ -192,7 +192,7 @@ class HapiReaderSuite extends CatsEffectSuite {
 
   test("gracefully reject responses with only the time parameter") {
     val parameters: List[Parameter] = List(
-      ScalarParameter("time", "isotime", "UTC", Option(24), None)
+      ScalarParameter("time", "isotime", Option("UTC"), Option(24), None)
     )
 
     assertEquals(reader.toModel(parameters), None)

--- a/src/test/scala/latis/input/HapiReaderSuite.scala
+++ b/src/test/scala/latis/input/HapiReaderSuite.scala
@@ -64,7 +64,7 @@ class HapiReaderSuite extends CatsEffectSuite {
   test("support vector timeseries datasets") {
     val parameters: List[Parameter] = List(
       ScalarParameter("time", "isotime", Option("UTC"), Option(24), None),
-      VectorParameter("x", "string", Option("units"), None, None, 3)
+      VectorParameter("x", "string", Option("units"), None, None, List(3))
     )
 
     reader.toModel(parameters) match {
@@ -83,8 +83,8 @@ class HapiReaderSuite extends CatsEffectSuite {
     val parameters: List[Parameter] = List(
       ScalarParameter("time", "isotime", Option("UTC"), Option(24), None),
       ScalarParameter("w", "string", Option("units"), None, None),
-      VectorParameter("x", "string", Option("units"), None, None, 2),
-      VectorParameter("y", "string", Option("units"), None, None, 2),
+      VectorParameter("x", "string", Option("units"), None, None, List(2)),
+      VectorParameter("y", "string", Option("units"), None, None, List(2)),
       ScalarParameter("z", "string", Option("units"), None, None)
     )
 
@@ -105,7 +105,7 @@ class HapiReaderSuite extends CatsEffectSuite {
   test("support datasets with a vector as the first non-time parameter") {
     val parameters: List[Parameter] = List(
       ScalarParameter("time", "isotime", Option("UTC"), Option(24), None),
-      VectorParameter("x", "string", Option("units"), None, None, 2),
+      VectorParameter("x", "string", Option("units"), None, None, List(2)),
       ScalarParameter("y", "string", Option("units"), None, None)
     )
 
@@ -123,8 +123,8 @@ class HapiReaderSuite extends CatsEffectSuite {
   test("support array parameters in datasets") {
     val parameters: List[Parameter] = List(
       ScalarParameter("time", "isotime", Option("UTC"), Option(24), None),
-      ArrayParameter("x", "string", Option("units"), None, None, 1,
-        Bin("w", "units")
+      ArrayParameter("x", "string", Option("units"), None, None, List(1),
+        List(Bin("w", "units"))
       )
     )
 
@@ -141,14 +141,14 @@ class HapiReaderSuite extends CatsEffectSuite {
   test("support multiple array parameters in datasets") {
     val parameters: List[Parameter] = List(
       ScalarParameter("time", "isotime", Option("UTC"), Option(24), None),
-      ArrayParameter("x", "string", Option("units"), None, None, 1,
-        Bin("w", "units")
+      ArrayParameter("x", "string", Option("units"), None, None, List(1),
+        List(Bin("w", "units"))
       ),
-      ArrayParameter("y", "string", Option("units"), None, None, 1,
-        Bin("w", "units")
+      ArrayParameter("y", "string", Option("units"), None, None, List(1),
+        List(Bin("w", "units"))
       ),
-      ArrayParameter("z", "string", Option("units"), None, None, 1,
-        Bin("w", "units")
+      ArrayParameter("z", "string", Option("units"), None, None, List(1),
+        List(Bin("w", "units"))
       )
     )
 
@@ -167,11 +167,11 @@ class HapiReaderSuite extends CatsEffectSuite {
   test("gracefully reject mixing array parameters with different bins") {
     val parameters: List[Parameter] = List(
       ScalarParameter("time", "isotime", Option("UTC"), Option(24), None),
-      ArrayParameter("x", "string", Option("units"), None, None, 1,
-        Bin("w", "units")
+      ArrayParameter("x", "string", Option("units"), None, None, List(1),
+        List(Bin("w", "units"))
       ),
-      ArrayParameter("y", "string", Option("units"), None, None, 1,
-        Bin("z", "units")
+      ArrayParameter("y", "string", Option("units"), None, None, List(1),
+        List(Bin("z", "units"))
       )
     )
 
@@ -182,8 +182,8 @@ class HapiReaderSuite extends CatsEffectSuite {
     val parameters: List[Parameter] = List(
       ScalarParameter("time", "isotime", Option("UTC"), Option(24), None),
       ScalarParameter("x", "string", Option("units"), None, None),
-      ArrayParameter("y", "string", Option("units"), None, None, 1,
-        Bin("w", "units")
+      ArrayParameter("y", "string", Option("units"), None, None, List(1),
+        List(Bin("w", "units"))
       )
     )
 

--- a/src/test/scala/latis/util/hapi/ParameterDecoderSuite.scala
+++ b/src/test/scala/latis/util/hapi/ParameterDecoderSuite.scala
@@ -1,6 +1,8 @@
 package latis.util
 package hapi
 
+import cats.data.NonEmptyList
+
 /** Tests for decoding HAPI parameters. */
 class ParameterDecoderSuite extends JsonDecoderSuite {
 
@@ -27,7 +29,7 @@ class ParameterDecoderSuite extends JsonDecoderSuite {
           assertEquals(units, Some("km/s"))
           assertEquals(length, None)
           assertEquals(fill, Some("-1.0E31"))
-          assertEquals(size, List(3,2))
+          assertEquals(size, NonEmptyList.of(3,2))
         case _ => fail("Decoded to wrong parameter type.")
       }
     }
@@ -36,13 +38,13 @@ class ParameterDecoderSuite extends JsonDecoderSuite {
   test("accept and decode parameters with a single bin") {
     withJsonResource("data/hapi-parameter-array.json") {
       decodedAs[Parameter](_) {
-        case ArrayParameter(name, tyName, units, length, fill, size, List(Bin(binName, binUnits))) =>
+        case ArrayParameter(name, tyName, units, length, fill, size, NonEmptyList(Bin(binName, binUnits), _)) =>
           assertEquals(name, "proton_spectrum_uncerts")
           assertEquals(tyName, "double")
           assertEquals(units, Some("particles/(sec ster cm^2 keV)"))
           assertEquals(length, None)
           assertEquals(fill, Some("-1e31"))
-          assertEquals(size, List(3))
+          assertEquals(size, NonEmptyList.of(3))
           assertEquals(binName, "energy")
           assertEquals(binUnits, "keV")
         case _ => fail("Decoded to wrong parameter type.")
@@ -54,8 +56,8 @@ class ParameterDecoderSuite extends JsonDecoderSuite {
     withJsonResource("data/hapi-parameter-array-multiple-bins.json") {
       decodedAs[Parameter](_) {
         case ArrayParameter(_, _, _, _, _, size, bins) =>
-          assertEquals(size, List(2,3))
-          assertEquals(bins, List(Bin("x", "m"), Bin("y", "m")))
+          assertEquals(size, NonEmptyList.of(2,3))
+          assertEquals(bins, NonEmptyList.of(Bin("x", "m"), Bin("y", "m")))
         case _ => fail("Decoded to wrong parameter type.")
       }
     }

--- a/src/test/scala/latis/util/hapi/ParameterDecoderSuite.scala
+++ b/src/test/scala/latis/util/hapi/ParameterDecoderSuite.scala
@@ -10,7 +10,7 @@ class ParameterDecoderSuite extends JsonDecoderSuite {
         case ScalarParameter(name, tyName, units, length, fill) =>
           assertEquals(name, "Np")
           assertEquals(tyName, "double")
-          assertEquals(units, "#/cc")
+          assertEquals(units, Some("#/cc"))
           assertEquals(length, None)
           assertEquals(fill, Some("-1.0E31"))
         case _ => fail("Decoded to wrong parameter type.")
@@ -24,7 +24,7 @@ class ParameterDecoderSuite extends JsonDecoderSuite {
         case VectorParameter(name, tyName, units, length, fill, size) =>
           assertEquals(name, "V_GSE")
           assertEquals(tyName, "double")
-          assertEquals(units, "km/s")
+          assertEquals(units, Some("km/s"))
           assertEquals(length, None)
           assertEquals(fill, Some("-1.0E31"))
           assertEquals(size, 3)
@@ -39,7 +39,7 @@ class ParameterDecoderSuite extends JsonDecoderSuite {
         case ArrayParameter(name, tyName, units, length, fill, size, Bin(binName, binUnits)) =>
           assertEquals(name, "proton_spectrum_uncerts")
           assertEquals(tyName, "double")
-          assertEquals(units, "particles/(sec ster cm^2 keV)")
+          assertEquals(units, Some("particles/(sec ster cm^2 keV)"))
           assertEquals(length, None)
           assertEquals(fill, Some("-1e31"))
           assertEquals(size, 3)
@@ -53,6 +53,16 @@ class ParameterDecoderSuite extends JsonDecoderSuite {
   test("reject parameters with multiple bins") {
     withJsonResource("data/hapi-parameter-array-multiple-bins.json") {
       doesNotDecodeAs[Parameter](_)("Failed to reject invalid parameter.")
+    }
+  }
+
+  test("accept and decode parameter with null units") {
+    withJsonResource("data/hapi-parameter-null-units.json") {
+      decodedAs[Parameter](_) {
+        case ScalarParameter(_, _, units, _, _) =>
+          assertEquals(units, None)
+        case _ => fail("Decoded to wrong parameter type.")
+      }
     }
   }
 }

--- a/src/test/scala/latis/util/hapi/ParameterDecoderSuite.scala
+++ b/src/test/scala/latis/util/hapi/ParameterDecoderSuite.scala
@@ -27,7 +27,7 @@ class ParameterDecoderSuite extends JsonDecoderSuite {
           assertEquals(units, Some("km/s"))
           assertEquals(length, None)
           assertEquals(fill, Some("-1.0E31"))
-          assertEquals(size, 3)
+          assertEquals(size, List(3,2))
         case _ => fail("Decoded to wrong parameter type.")
       }
     }
@@ -36,13 +36,13 @@ class ParameterDecoderSuite extends JsonDecoderSuite {
   test("accept and decode parameters with a single bin") {
     withJsonResource("data/hapi-parameter-array.json") {
       decodedAs[Parameter](_) {
-        case ArrayParameter(name, tyName, units, length, fill, size, Bin(binName, binUnits)) =>
+        case ArrayParameter(name, tyName, units, length, fill, size, List(Bin(binName, binUnits))) =>
           assertEquals(name, "proton_spectrum_uncerts")
           assertEquals(tyName, "double")
           assertEquals(units, Some("particles/(sec ster cm^2 keV)"))
           assertEquals(length, None)
           assertEquals(fill, Some("-1e31"))
-          assertEquals(size, 3)
+          assertEquals(size, List(3))
           assertEquals(binName, "energy")
           assertEquals(binUnits, "keV")
         case _ => fail("Decoded to wrong parameter type.")
@@ -50,9 +50,14 @@ class ParameterDecoderSuite extends JsonDecoderSuite {
     }
   }
 
-  test("reject parameters with multiple bins") {
+  test("accept and decode parameters with multiple bins") {
     withJsonResource("data/hapi-parameter-array-multiple-bins.json") {
-      doesNotDecodeAs[Parameter](_)("Failed to reject invalid parameter.")
+      decodedAs[Parameter](_) {
+        case ArrayParameter(_, _, _, _, _, size, bins) =>
+          assertEquals(size, List(2,3))
+          assertEquals(bins, List(Bin("x", "m"), Bin("y", "m")))
+        case _ => fail("Decoded to wrong parameter type.")
+      }
     }
   }
 


### PR DESCRIPTION
The HAPI spec requires parameters to have `units` but allows them to be `null` (as I discovered in https://cdaweb.gsfc.nasa.gov/hapi/info?id=OMNI_HRO2_1MIN). The changes here allow optional units to support the null case. The LaTiS model has optional units so the mapping is trivial. HAPI also supports arrays of units for array parameters. I made a new ticket to add support for that.

Note that the HAPI info encoder (which enforces the inclusion of units, even if null) uses a different "parameter" abstraction in the hapi-server. (Should we use the same one?)

The HAPI spec also supports multi-dimensional array parameters. We had been supporting only 1D (beyond time). The parameter model now supports nD. The `HapiReader` is still limited (to 1D nested Functions?) but I don't think we are using it, yet. The `HapiAdapter` simply assumes a 1D time series based on the HAPI CSV output with one row per time. The model defined in the FDML uses "._#" notation to treat each array component as a separate variable. It might just work for nD array parameters. However, the cases I ran into have nD parameters but we aren't using any of them. We only need the support in the info model right now. We can worry about supporting such data another day.