### PR TITLE
Pad stop time

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
 ThisBuild / organization := "io.latis-data"
 ThisBuild / scalaVersion := "2.13.8"
 
-val latisVersion  = "de6724b"
-val circeVersion  = "0.14.2"
-val http4sVersion = "0.23.15"
+val latisVersion  = "ea2ab6c"
+val circeVersion  = "0.14.5"
+val http4sVersion = "0.23.23"
 
 lazy val hapi = (project in file("."))
   .settings(commonSettings)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.1
+sbt.version=1.9.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
-addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.1")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
+addSbtPlugin("org.typelevel" % "sbt-tpolecat" % "0.5.0")

--- a/src/main/scala/latis/input/HapiAdapter.scala
+++ b/src/main/scala/latis/input/HapiAdapter.scala
@@ -153,15 +153,19 @@ abstract class HapiAdapter(model: DataType, config: HapiAdapter.Config) extends 
     }.fold(throw _, identity)
   }
 
-  /** Gets the time coverage from the HAPI info. */
-  //TODO: use the HAPI sampleStartDate and sampleStopDate if available
-  //  See: https://github.com/latis-data/latis3-hapi/issues/9
+  /**
+   * Gets the default time coverage from the HAPI info.
+   *
+   * The end time will be padded an extra second since the max time is
+   * specified to be exclusive and we don't want to risk missing the
+   * last sample.
+   */
   def defaultTimeCoverage(): (Long, Long) = {
     val info = readInfo()
     val either = for {
       start <- TimeFormat.parseIso(info.startDate)
       stop  <- TimeFormat.parseIso(info.stopDate)
-    } yield (start, stop)
+    } yield (start, stop + 1000L) //pad stop time one second
     either.getOrElse {
       val msg = "Failed to get time coverage from HAPI info"
       throw LatisException(msg)


### PR DESCRIPTION
A hapi data request requires a min and max time. LaTiS does not. The LaTiS hapi adapter uses the coverage information from the hapi info response to construct a default time range. In some cases the `stopDate` is equal to the time of the last sample. However, the hapi spec says that `time.max` is exclusive. Thus there is the risk of losing the last sample.

This PR adds a one second padding to the default end time so we can get the last sample in such cases. Note that there is a risk of getting more data than requested for data with higher resolution than one-second. (Note that one server I tried did not preserve millisecond precision so a ms pad was not sufficient.)
